### PR TITLE
only enable gradle menu when the gradle nature is present

### DIFF
--- a/org.springsource.ide.eclipse.gradle.ui/plugin.xml
+++ b/org.springsource.ide.eclipse.gradle.ui/plugin.xml
@@ -33,10 +33,10 @@
             objectClass="org.eclipse.core.resources.IResource"
              adaptable="true"
              id="org.springsource.ide.eclipse.gradle.menu">
-<!--   		<filter
+   		<filter
            name="projectNature"
            value="org.springsource.ide.eclipse.gradle.core.nature">
-        </filter> -->
+        </filter>
         <menu
              label="Gradle"
              id="org.springsource.ide.eclipse.gradle.menu">


### PR DESCRIPTION
undoes the commented out filter to only display the gradle menu when the nature has been added.
