### PR TITLE
fix warnings about non existent menu

### DIFF
--- a/org.springsource.ide.eclipse.gradle.ui/plugin.xml
+++ b/org.springsource.ide.eclipse.gradle.ui/plugin.xml
@@ -33,10 +33,6 @@
             objectClass="org.eclipse.core.resources.IResource"
              adaptable="true"
              id="org.springsource.ide.eclipse.gradle.menu">
-   		<filter
-           name="projectNature"
-           value="org.springsource.ide.eclipse.gradle.core.nature">
-        </filter>
         <menu
              label="Gradle"
              id="org.springsource.ide.eclipse.gradle.menu">
@@ -44,6 +40,9 @@
             <separator name="toggle"/>
             <separator name= "refresh"/>
         </menu> 
+        <visibility>
+            <objectState name="nature" value="org.springsource.ide.eclipse.gradle.core.nature"/>
+        </visibility>
       </objectContribution>
       
       <objectContribution


### PR DESCRIPTION
The previous pull request to disable the gradle menu when the gradle nature was not present logs several warnings/errors about the menu not existing.  This pull request removes those errors.
