### PR TITLE
Ensure Gradle menu is available when contributing menu items

### DIFF
--- a/org.springsource.ide.eclipse.gradle.ui/plugin.xml
+++ b/org.springsource.ide.eclipse.gradle.ui/plugin.xml
@@ -43,12 +43,6 @@
         <visibility>
             <objectState name="nature" value="org.springsource.ide.eclipse.gradle.core.nature"/>
         </visibility>
-      </objectContribution>
-      
-      <objectContribution
-            objectClass="org.eclipse.core.resources.IResource"
-             adaptable="true"
-             id="org.springsource.ide.eclipse.gradle.actions">
         <action
                class="org.springsource.ide.eclipse.gradle.ui.actions.RefreshAllAction"
                enablesFor="+"


### PR DESCRIPTION
This fixes the menu extension discussed here: https://github.com/spring-projects/eclipse-integration-gradle/pull/66

The deprecated objectContribution actions are funny in that you can't guarantee the order at which they will load, so in this case if eclipse reads the 2nd objectContribution with the actions before it reads the 1st objectContribution with the menu it will complain "invalid path", but eventually the menu is added so things seem to work out (that is why the menu can be seen at all I guess).

But this fix simply moves all of the actions for the menu into the same objectContribution as the menu itself.
