### PR TITLE
Adds a global "Ctrl+F5" refresh All command

### DIFF
--- a/org.springsource.ide.eclipse.gradle.ui/plugin.xml
+++ b/org.springsource.ide.eclipse.gradle.ui/plugin.xml
@@ -38,17 +38,18 @@
              id="org.springsource.ide.eclipse.gradle.menu">
             <separator name="actions"/>
             <separator name="toggle"/>
-            <separator name= "refresh"/>
+            <separator name="refresh"/>
         </menu> 
         <visibility>
             <objectState name="nature" value="org.springsource.ide.eclipse.gradle.core.nature"/>
         </visibility>
         <action
-               class="org.springsource.ide.eclipse.gradle.ui.actions.RefreshAllAction"
-               enablesFor="+"
-               id="org.springsource.ide.eclipse.gradle.actions.refresh.all"
-               label="Refresh All"
-               menubarPath="org.springsource.ide.eclipse.gradle.menu/refresh">
+              class="org.springsource.ide.eclipse.gradle.ui.actions.RefreshAllAction"
+              definitionId="org.springsource.ide.eclipse.gradle.ui.refresh.all"
+              enablesFor="+"
+              id="org.springsource.ide.eclipse.gradle.actions.refresh.all"
+              label="Refresh All"
+              menubarPath="org.springsource.ide.eclipse.gradle.menu/refresh">
          </action>
         <action
                class="org.springsource.ide.eclipse.gradle.ui.actions.RefreshSourceFoldersAction"
@@ -330,6 +331,12 @@
             id="org.springsource.ide.eclipse.gradle.ui.OpenTasksQuickLauncher"
             name="Open Gradle Tasks Quick Launcher">
       </command>
+      <command
+            categoryId="org.springsource.ide.eclipse.gradle.ui.commands"
+            description="Refresh All both dependecies and source folders for selected gradle project"
+            id="org.springsource.ide.eclipse.gradle.ui.refresh.all"
+            name="Refresh All">
+      </command>
    </extension>
    <extension
          point="org.eclipse.ui.bindings">
@@ -338,6 +345,12 @@
             contextId="org.eclipse.ui.contexts.window"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+M2+M3+R">
+      </key>
+      <key
+            commandId="org.springsource.ide.eclipse.gradle.ui.refresh.all"
+            contextId="org.eclipse.ui.contexts.window"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+F5">
       </key>
    </extension>
    <extension
@@ -354,6 +367,13 @@
                label="Open Gradle Tasks Quick Launcher">
          </action>
       </actionSet>
+   </extension>
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="org.springsource.ide.eclipse.gradle.ui.actions.RefreshAllHandler"
+            commandId="org.springsource.ide.eclipse.gradle.ui.refresh.all">
+      </handler>
    </extension>
 
 </plugin>

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/GradleProjectActionDelegate.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/GradleProjectActionDelegate.java
@@ -65,6 +65,19 @@ public abstract class GradleProjectActionDelegate implements IObjectActionDelega
 						projects.add((IProject) element);
 					} else if (element instanceof IResource) {
 						projects.add(((IResource) element).getProject());
+					} else if (element instanceof IAdaptable) {
+					    IAdaptable adaptable = (IAdaptable) element;
+					    IProject project = (IProject) adaptable.getAdapter( IProject.class );
+					    if(project == null) {
+					        IResource resource = (IResource) adaptable.getAdapter( IResource.class );
+					        if (resource != null ) {
+					            project = resource.getProject();
+					        }
+					    }
+
+					    if (project != null ) {
+					        projects.add(project);
+					    }
 					} else if (element instanceof IWorkingSet) {
 						IWorkingSet workingSet = (IWorkingSet) element;
 						for (IAdaptable adaptable : workingSet.getElements()) {

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshAllHandler.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshAllHandler.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Liferay, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Gregory Amerson - initial API and implementation
+ *******************************************************************************/
+package org.springsource.ide.eclipse.gradle.ui.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+
+/**
+ * @author Gregory Amerson
+ */
+public class RefreshAllHandler extends AbstractHandler {
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        final ISelection selection = HandlerUtil.getCurrentSelection(event);
+        final RefreshAllAction refreshAllAction = new RefreshAllAction();
+        final IAction action = new Action(){};
+
+        refreshAllAction.selectionChanged(action, selection);
+
+        if (action.isEnabled()) {
+            refreshAllAction.run(action);
+        }
+
+        return null;
+    }
+
+}


### PR DESCRIPTION
I found myself wanting a global "refresh all" shortcut similar to the m2e "alt+F5" so this pull adds a "ctrl+F5" global shortcut that calls "refresh all" action if appropriate (refreshAll is enabled).

![workspace 1_069](https://cloud.githubusercontent.com/assets/595221/5334922/fabcbdd4-7ed8-11e4-941a-0cf1eaf6e8c6.png)
