### PR TITLE
Custom tooling model is not adding classpath entries for gradleApi(), localGroovy()

### DIFF
--- a/toolingapi/integrationTests/projects/pluginproject/build.gradle
+++ b/toolingapi/integrationTests/projects/pluginproject/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java'
+
+dependencies {
+	compile gradleApi()
+}


### PR DESCRIPTION
The changes add external dependency entries for 'local dependencies' like gradleApi(), localGroovy().  Note that in the case of gradleApi(), this actually represents a set of many jars.

We should not expect that conflict resolution is provided between jars included through local dependencies and those included through normal dependencies.  Gradle itself does not provide this mechanism yet.
