### PR TITLE
Re-ordered remapped project references to be put at the end of the classpath

### DIFF
--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ClassPath.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ClassPath.java
@@ -67,10 +67,10 @@ public class ClassPath {
 	 */
 	public static final int[] kindOrdering = {
 		IClasspathEntry.CPE_SOURCE,
-		IClasspathEntry.CPE_PROJECT,
 		IClasspathEntry.CPE_LIBRARY,
 		IClasspathEntry.CPE_CONTAINER,
-		IClasspathEntry.CPE_VARIABLE
+		IClasspathEntry.CPE_VARIABLE,
+		IClasspathEntry.CPE_PROJECT
 	};
 	
 	/**


### PR DESCRIPTION
Due to the order of dependencies on the build path with projects coming before artifact dependencies, this causes issues during runtime if you have dependencies on third party artifacts.

Eg

Project A:

``` groovy
...
dependencies {
    compile "org.springframework:spring-web:3.2.0.RELEASE"
}
...
```

Project B:

``` groovy
...
dependencies {
    compile "group:project-a:+"
    compile "org.springframework:spring-web:4.1.0.RELEASE"
}
...
```

Given the above two projects, where 'project-a' maps to the local project 'Project A' the order or dependencies on the build path is incorrect. With the plugin's current order, it results in the 3.2.0 dependency being presented first in the runtime classpath when running 'Project B' instead of the properly resolved 4.1.0 dependency that is shown in the classpath container and what would be resolved by invoking gradle from the command line.
