### PR TITLE
Add "Alphabetically by name" option in Gradle dependency sorting strategy

### DIFF
--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleImportTests.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleImportTests.java
@@ -76,43 +76,43 @@ import org.springsource.ide.eclipse.gradle.core.wtp.WTPUtil;
 /**
  * Basic tests for the GradleImport operation. Imports a project, all its subprojects using
  * default settings.
- * 
+ *
  * @author Kris De Volder
  */
 public class GradleImportTests extends GradleTest {
-	
+
 	public void testImportBasic() throws Exception {
 		String projectName = "quickstart";
 		File projectLoc = extractJavaSample(projectName);
 		GradleImportOperation importOp = importTestProjectOperation(projectLoc);
-		
+
 		performImport(importOp);
 		GradleProject project = getGradleProject(projectName);
-		
+
 		assertProjects(projectName); //no compile errors?
-		
+
 		assertTrue("Should have classpath container", GradleClassPathContainer.isOnClassPath(project.getJavaProject()));
 		assertTrue("Gradle nature added?", GradleNature.hasNature(getProject(projectName)));
 	}
-	
+
 	public void testImportNoClasspathContainer() throws Exception {
 		String projectName = "quickstart";
 		File projectLoc = extractJavaSample(projectName);
 		GradleImportOperation importOp = importTestProjectOperation(projectLoc);
 		importOp.setEnableDependencyManagement(false); //use default values for everything else.
-		
+
 		performImport(importOp);
 		GradleProject project = getGradleProject(projectName);
-		
+
 		assertProjects(projectName); //no compile errors?
-		
-		assertFalse("Shouldn't have classpath container", 
+
+		assertFalse("Shouldn't have classpath container",
 				GradleClassPathContainer.isOnClassPath(project.getJavaProject()));
 		assertTrue("Gradle nature added?", GradleNature.hasNature(getProject(projectName)));
 	}
-	
+
 	public void _testImportSpringFramework() throws Exception {
-		//Disabled this test, unstable on CI builds. For some unkonw reason 
+		//Disabled this test, unstable on CI builds. For some unkonw reason
 		// Eclipse on CI gets randomly confused about Java 8 JDK being of an 'unknown version'.
 		JavaXXRuntime.java8everyone();
 		String[] projectNames = {
@@ -143,7 +143,7 @@ public class GradleImportTests extends GradleTest {
 				"spring-webmvc-tiles2",
 				"spring-websocket"
 		};
-		
+
 		//			boolean good = false;
 		//			while(!good) {
 		//				try {
@@ -152,26 +152,26 @@ public class GradleImportTests extends GradleTest {
 		//				} catch (InterruptedException e) {
 		//				}
 		//			}
-		//		
-// Use wrapper version
-//		URI distro = new URI("http://services.gradle.org/distributions/gradle-1.3-bin.zip");
-//		GradleCore.getInstance().getPreferences().setDistribution(distro);
+		//
+		// Use wrapper version
+		//		URI distro = new URI("http://services.gradle.org/distributions/gradle-1.3-bin.zip");
+		//		GradleCore.getInstance().getPreferences().setDistribution(distro);
 
-		final GradleImportOperation importOp = importGitProjectOperation(new GitProject("spring-framework", 
+		final GradleImportOperation importOp = importGitProjectOperation(new GitProject("spring-framework",
 				new URI("git://github.com/SpringSource/spring-framework.git"),
 				//"db3bbb5f8cb945b8f29fbd83aff9bbd2dbc70e1c"
 				"v4.1.1.RELEASE"
-			)
-		);
+				)
+				);
 
 		String[] beforeTasks = {
 				//These tasks are set based on the shell script included with spring framework:
 				//https://github.com/SpringSource/spring-framework/blob/0ae973f995229bce0c5b9ffe25fe1f5340559656/import-into-eclipse.sh
 				"cleanEclipse",
-				"eclipse",				
+				"eclipse",
 				":spring-oxm:compileTestJava",
 		};
-		
+
 		importOp.setEnableDependencyManagement(false);
 		importOp.setDoBeforeTasks(true);
 		importOp.setBeforeTasks(beforeTasks);
@@ -184,7 +184,7 @@ public class GradleImportTests extends GradleTest {
 		//		for (IProject p : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
 		//			System.out.println(p.getName());
 		//		}
-		
+
 		//check that the refresh preferences got setup properly (only checking one property).
 		//the one that has a non-default value.
 		GradleProject project = getGradleProject("spring-aspects");
@@ -197,18 +197,18 @@ public class GradleImportTests extends GradleTest {
 	public void testSTS2407OutputFolderDependencyInNestedMultiproject() throws Exception {
 		String[] projectNames = {
 				"sts-2407",
-				"buildutilities", 
-				"projectA", 
-				"projectB", 
-				"projectC", 
+				"buildutilities",
+				"projectA",
+				"projectB",
+				"projectC",
 				"projectD",
 		};
 		importTestProject(projectNames[0]);
 		assertProjects(projectNames);
 	}
-	
+
 	public void testSTS2276SetJavaHome() throws Exception {
-		//This test merely verifies whether nothing breaks when we set the JavaHome property. 
+		//This test merely verifies whether nothing breaks when we set the JavaHome property.
 		//It doesn't actually test whether this setting actually makes Gradle use that JVM (how could we test that???)
 		IVMInstall defaultVM = JavaRuntime.getDefaultVMInstall();
 		try {
@@ -219,7 +219,7 @@ public class GradleImportTests extends GradleTest {
 			assertProjects(
 					projectName,
 					subprojectName);
-			
+
 		} finally {
 			GradleCore.getInstance().getPreferences().unsetJavaHome(); //Reset to default
 		}
@@ -228,27 +228,27 @@ public class GradleImportTests extends GradleTest {
 	public void DISABLEDtestImportSpringSecurity() throws Exception {
 		//Test disabled. To reenable need to use more recent version of spring-security that is compatible
 		// with current groovy eclipse compiler.
-		
+
 		setSnapshotDistro();
-		GradleImportOperation importOp = importGitProjectOperation(new GitProject("spring-security", 
+		GradleImportOperation importOp = importGitProjectOperation(new GitProject("spring-security",
 				new URI("git://github.com/SpringSource/spring-security.git"),
 				"66357a2077cb3d94657a5b759771572a341e55f4"
 				//"191fc9c8be80c7338ab8e183014de48f78fcffd1"
-		));
-		
+				));
+
 		importOp.setDoBeforeTasks(true);
-		
+
 		performImport(importOp,
 				//Ignore errors: (expected!)
 				"Project 'spring-security-aspects' is an AspectJ project",
 				"Project 'spring-security-samples-aspectj' is an AspectJ project"
-		);
-		
+				);
+
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
 		for (IProject proj : projects) {
 			System.out.println("\""+proj.getName()+"\","); //print out in a format convenient to copy paste below
 		}
-		
+
 		assertProjects(
 				"docs-3.2.x",
 				"faq-3.2.x",
@@ -279,11 +279,11 @@ public class GradleImportTests extends GradleTest {
 				"spring-security-samples-tutorial-3.2.x",
 				"spring-security-taglibs-3.2.x",
 				"spring-security-web-3.2.x"
-		);
-		
+				);
+
 		assertTrue(WTPUtil.isWTPProject(getProject("spring-security-samples-jaas-3.2.x")));
 	}
-	
+
 	public void testSTS2185AddWebAppLibrariesContainerToWTPProjects() throws Exception {
 		assertTrue("This test requires WTP functionality to be installed", WTPUtil.isInstalled());
 		String[] projectNames = {
@@ -299,8 +299,8 @@ public class GradleImportTests extends GradleTest {
 			@Override
 			public boolean test() throws Exception {
 				/////////////////////
-				//Check project A: 
-				{ 
+				//Check project A:
+				{
 					IJavaProject project = getJavaProject("A");
 
 					IClasspathEntry[] rawClasspath = project.getRawClasspath();
@@ -310,18 +310,18 @@ public class GradleImportTests extends GradleTest {
 					assertClasspathContainer(rawClasspath, WTPUtil.JST_J2EE_WEB_CONTAINER);
 
 					//Can we find 'junk.jar' from the WEB-INF/lib directory of project A.
-					assertClasspathJarEntry("junk.jar", resolvedClasspath); 
+					assertClasspathJarEntry("junk.jar", resolvedClasspath);
 				}
 
 				/////////////////////
-				//Check project B: 
-				{ 
+				//Check project B:
+				{
 					IJavaProject project = getJavaProject("B");
 
 					IClasspathEntry[] rawClasspath = project.getRawClasspath();
 
 					//It is a WTP project...
-					assertTrue(WTPUtil.isWTPProject(project.getProject())); 
+					assertTrue(WTPUtil.isWTPProject(project.getProject()));
 
 					//... but shouldn't have libraries container because not a jst.web project.
 					assertNoClasspathContainer(rawClasspath, WTPUtil.JST_J2EE_WEB_CONTAINER);
@@ -330,7 +330,7 @@ public class GradleImportTests extends GradleTest {
 			}
 		}.waitFor(10000);
 	}
-	
+
 	private void assertNoClasspathContainer(IClasspathEntry[] rawClasspath, String pathStr) {
 		IPath path = new Path(pathStr);
 		StringBuilder msg = new StringBuilder();
@@ -350,27 +350,27 @@ public class GradleImportTests extends GradleTest {
 				"greeteds.world",
 				"hello"
 		};
-		
+
 		importTestProject(projectNames[0]);
 		assertProjects(projectNames);
 	}
-	
-	
+
+
 
 	public void _testSTS1950RuntimeClasspathMergingFromSubprojectContainers() throws Exception {
-		//TODO: This test was disabled because test projects had a bunch of jars in it that 
+		//TODO: This test was disabled because test projects had a bunch of jars in it that
 		// we would have to raise IP log tickets for to put it on the open-sourced git repo.
 		// Should try to reinstate the test in future.
 		String[] projectNames = {
 				"sts1950",
 				"A", "B", "C"
 		};
-		
+
 		importTestProject(projectNames[0]);
 		assertProjects(projectNames);
-		
+
 		IJavaProject project = getJavaProject("B");
-		
+
 		ILaunchConfigurationWorkingCopy launchConf = JUnitLaunchConfigUtil.createLaunchConfiguration(project);
 		IRuntimeClasspathEntry[] classpath = JavaRuntime.computeUnresolvedRuntimeClasspath(launchConf);
 		System.out.println(">>> Raw runtime classpath for B");
@@ -378,7 +378,7 @@ public class GradleImportTests extends GradleTest {
 			System.out.println(e);
 		}
 		System.out.println("<<< Raw runtime classpath for B");
-		
+
 		IRuntimeClasspathEntry[] runtimeClasspath = JavaRuntime.resolveRuntimeClasspath(classpath, launchConf);
 		System.out.println(">>> Runtime classpath for B");
 		for (IRuntimeClasspathEntry entry : runtimeClasspath) {
@@ -388,7 +388,7 @@ public class GradleImportTests extends GradleTest {
 		assertClasspathEntry("glazedlists-1.8.0-java15.jar", runtimeClasspath);
 		assertClasspathEntry("junit-4.4.jar", runtimeClasspath);
 	}
-	
+
 	private void assertClasspathEntry(String jarFile, IRuntimeClasspathEntry[] runtimeClasspath) {
 		StringBuilder msg = new StringBuilder("Not found: "+jarFile+"\nFound:\n");
 		for (IRuntimeClasspathEntry e : runtimeClasspath) {
@@ -404,72 +404,72 @@ public class GradleImportTests extends GradleTest {
 	}
 
 	public void testSTS2202ImportFromSymlink() throws Exception {
-		//Reuse test project for sts2175 
+		//Reuse test project for sts2175
 		String[] projectNames = {
 				"sts2175",
 				"suba",
 				"subb",
 				"subc"
 		};
-		
+
 		File testProj = getTestProjectCopy(projectNames[0]);
 		File tmpDir = TestUtils.createTempDirectory();
 		File link = new File(tmpDir, projectNames[0]);
 		Process process = Runtime.getRuntime().exec(new String[] {
-			"ln",
-			"-s",
-			testProj.toString(),
-			link.toString()
+				"ln",
+				"-s",
+				testProj.toString(),
+				link.toString()
 		});
 		assertEquals(0, process.waitFor());
 		assertTrue(link.exists());
 		assertTrue(link.isDirectory());
 		importTestProject(link);
-		
-		assertProjects(projectNames);
-		
-	}
-	
-//	/**
-//	 * Projects that use version of wrapper generated pre 0.9 will have a wrapper properties file
-//	 * that can't be read by 1.0-milestone-3, this causes a crash without a very good error message.
-//	 * <p>
-//	 * We attempt to recover from it by forcing a more recent version of Gradle, bypassing the wrapper
-//	 * completely.
-//	 * 
-//	 * @throws Exception
-//	 */
-//	public void testImportOldWrapperFormat() throws Exception {
-//		String projectName = "oldWrapperFormat";
-//		GradleTest.MockFallBackDialog dialog = new GradleTest.MockFallBackDialog(true);
-//		FallBackDistributionCore.setTestDialogProvider(dialog);
-//		
-//		importTestProject(projectName);
-//		assertTrue(""+dialog.projectLoc, (""+dialog.projectLoc).endsWith(projectName)); //check if dialog called as expected
-//		
-//		assertProjects(projectName); //Check project imported and no errors.
-//	}
 
-//	/**
-//	 * Different from earlier case: the wrapper format is readable by the tooling API, but it
-//	 * specifies a version of Gradle that is too old.
-//	 * <p>
-//	 * Again, we should attempt to recover by trying to use more recent version.
-//	 */
-//	public void testImportTooOldVersionInWrapper() throws Exception {
-//		String projectName = "oldWrapperVersion";
-//		GradleTest.MockFallBackDialog dialog = new GradleTest.MockFallBackDialog(true);
-//		FallBackDistributionCore.setTestDialogProvider(dialog);
-//		
-//		importTestProject(projectName);
-//		assertTrue(""+dialog.projectLoc, (""+dialog.projectLoc).endsWith(projectName)); //check if dialog called as expected
-//		
-//		assertProjects(projectName); //Check project imported and no errors.
-//	}
-	
+		assertProjects(projectNames);
+
+	}
+
+	//	/**
+	//	 * Projects that use version of wrapper generated pre 0.9 will have a wrapper properties file
+	//	 * that can't be read by 1.0-milestone-3, this causes a crash without a very good error message.
+	//	 * <p>
+	//	 * We attempt to recover from it by forcing a more recent version of Gradle, bypassing the wrapper
+	//	 * completely.
+	//	 *
+	//	 * @throws Exception
+	//	 */
+	//	public void testImportOldWrapperFormat() throws Exception {
+	//		String projectName = "oldWrapperFormat";
+	//		GradleTest.MockFallBackDialog dialog = new GradleTest.MockFallBackDialog(true);
+	//		FallBackDistributionCore.setTestDialogProvider(dialog);
+	//
+	//		importTestProject(projectName);
+	//		assertTrue(""+dialog.projectLoc, (""+dialog.projectLoc).endsWith(projectName)); //check if dialog called as expected
+	//
+	//		assertProjects(projectName); //Check project imported and no errors.
+	//	}
+
+	//	/**
+	//	 * Different from earlier case: the wrapper format is readable by the tooling API, but it
+	//	 * specifies a version of Gradle that is too old.
+	//	 * <p>
+	//	 * Again, we should attempt to recover by trying to use more recent version.
+	//	 */
+	//	public void testImportTooOldVersionInWrapper() throws Exception {
+	//		String projectName = "oldWrapperVersion";
+	//		GradleTest.MockFallBackDialog dialog = new GradleTest.MockFallBackDialog(true);
+	//		FallBackDistributionCore.setTestDialogProvider(dialog);
+	//
+	//		importTestProject(projectName);
+	//		assertTrue(""+dialog.projectLoc, (""+dialog.projectLoc).endsWith(projectName)); //check if dialog called as expected
+	//
+	//		assertProjects(projectName); //Check project imported and no errors.
+	//	}
+
 	public void testSTS2058ImportProjectThatIsStoredInWorkspaceLocation() throws Exception {
 		IPath workspaceLoc = Platform.getLocation();
-		
+
 		String[] projectNames = {
 				"multiproject",
 				"api",
@@ -478,45 +478,45 @@ public class GradleImportTests extends GradleTest {
 				"webservice",
 				"shared"
 		};
-		
+
 		String projectName = projectNames[0];
 		File orgTestProject = extractJavaSample(projectName);
 		File inWorkspaceCopy = new File(workspaceLoc.toFile(), projectName);
 
 		FileUtils.copyDirectory(orgTestProject, inWorkspaceCopy);
-		
+
 		importTestProject(inWorkspaceCopy);
-		
+
 		assertProjects(
 				projectNames
-		);
-		
+				);
+
 		IJavaProject shared = getJavaProject("shared");
 		assertSourceFolder(shared, "src/main/java");
 		assertSourceFolder(shared, "src/main/resources");
 		assertSourceFolder(shared, "src/test/java");
 		assertSourceFolder(shared, "src/test/resources");
-	}		
-	
-	/** 
+	}
+
+	/**
 	 * Import preserves existing source folder exclusion filters?
 	 */
 	public void testSTS2205PreserveSourceFolderExclusions() throws Exception {
 		String projectName = "sts_2205";
 		File projectLoc = getTestProjectCopy(projectName);
 		GradleImportOperation importOp = importTestProjectOperation(projectLoc);
-		
-		 //Check that the import operation has the expected default options
+
+		//Check that the import operation has the expected default options
 		assertTrue(importOp.getDoBeforeTasks());
-		assertTrue(importOp.getDoAfterTasks()); 
-		assertArrayEquals(new String[] { "cleanEclipse", "eclipse" }, 
+		assertTrue(importOp.getDoAfterTasks());
+		assertArrayEquals(new String[] { "cleanEclipse", "eclipse" },
 				importOp.getBeforeTasks());
-		assertArrayEquals(new String[] { "afterEclipseImport" }, 
+		assertArrayEquals(new String[] { "afterEclipseImport" },
 				importOp.getAfterTasks());
-		
+
 		importOp.perform(defaultTestErrorHandler(), new NullProgressMonitor());
 		assertProjects(projectName);
-		
+
 		//Check expected source folder has expected exclusions
 		GradleProject gp = getGradleProject(projectName);
 		ClassPath classpath = gp.getClassPath();
@@ -524,41 +524,41 @@ public class GradleImportTests extends GradleTest {
 		assertEquals("Source folder count", 1, srcFolders.length);
 		IClasspathEntry entry = srcFolders[0];
 		IPath[] exclusions = entry.getExclusionPatterns();
-		assertArrayEquals(new IPath[] { new Path("testb2/**/*")}, 
+		assertArrayEquals(new IPath[] { new Path("testb2/**/*")},
 				exclusions);
 	}
-	
+
 	public void testImportJavaQuickStart() throws Exception {
-//		GradleClassPathContainer.DEBUG = true;
+		//		GradleClassPathContainer.DEBUG = true;
 		String name = "quickstart";
 		importSampleProject(name);
-		
+
 		IJavaProject project = getJavaProject(name);
 		dumpJavaProjectInfo(project);
-		
+
 		assertProjects(name);
-		
+
 		assertJarEntry(project, "commons-collections-3.2.jar", true);
 		assertJarEntry(project, "junit-4.12.jar", true);
-//		assertJarEntry(project, "bogus-4.8.2.jar", true);
+		//		assertJarEntry(project, "bogus-4.8.2.jar", true);
 	}
-	
+
 	public void testImportJavaQuickStartAndRefresh() throws Exception {
-//		GradleClassPathContainer.DEBUG = true;
+		//		GradleClassPathContainer.DEBUG = true;
 		String name = "quickstart";
 		importSampleProject(name);
-		
+
 		IJavaProject project = getJavaProject(name);
 		GradleProject gp = GradleCore.create(project);
 		dumpJavaProjectInfo(project);
-		
+
 		assertProjects(name);
 		assertJarEntry(project, "commons-collections-3.2.jar", true);
 		assertJarEntry(project, "junit-4.12.jar", true);
 		assertTrue("Dependency management should be enabled", gp.isDependencyManaged());
-		
+
 		RefreshAllActionCore.callOn(Arrays.asList(gp.getProject())).join();
-		
+
 		//Project should basically still be the same:
 		assertProjects(name);
 		assertJarEntry(project, "commons-collections-3.2.jar", true);
@@ -578,43 +578,43 @@ public class GradleImportTests extends GradleTest {
 		assertFalse("Dependency management should be disabled", gp.isDependencyManaged());
 
 	}
-	
-	
+
+
 	/**
 	 * Test whether afterImportTasks are executed after an import
 	 */
 	public void testAfterImportTasksExecuted() throws Exception {
 		String projName = "afterImportTask";
-		
+
 		//Create a simple test project with a simple tasks
-		GradleTaskRunTest.simpleProject(projName, 
+		GradleTaskRunTest.simpleProject(projName,
 				"apply plugin: 'java'\n" +
-				"task afterEclipseImport << {\n" +
-				"	File f = new File(\"$projectDir/sub/test.txt\")\n" + 
-				"   f.getParentFile().mkdirs();\n" +
-				"   f.write 'This is a test'\n"+
+						"task afterEclipseImport << {\n" +
+						"	File f = new File(\"$projectDir/sub/test.txt\")\n" +
+						"   f.getParentFile().mkdirs();\n" +
+						"   f.write 'This is a test'\n"+
 				"}\n");
-		
+
 		//simpl project creation actually uses 'import' to get project into workspace so...
 		//the afterEclipseImport task should have run.
-		
+
 		IProject project = getProject(projName);
 		File location = project.getLocation().toFile();
-		
+
 		IFile theFile = project.getFile("sub/test.txt");
 		assertTrue(theFile.exists());
-		
+
 		//Now try again... reimport the project, but with the option to run the task disabled.
 		theFile.delete(true, new NullProgressMonitor());
 		project.delete(false, true, new NullProgressMonitor());
-		
+
 		GradleImportOperation importOp = importTestProjectOperation(location);
 		importOp.setDoAfterTasks(false);
-		
+
 		importOp.perform(new ErrorHandler.Test(), new NullProgressMonitor());
 		assertFalse(theFile.exists());
 	}
-	
+
 	public void testImportAfterGradleEclipseTask() throws Exception {
 		String projectName = "quickstart";
 		File location = extractJavaSample(projectName);
@@ -622,22 +622,22 @@ public class GradleImportTests extends GradleTest {
 		generateEclipseFiles(testProj);
 		testProj.invalidateGradleModel(); // import must be as if model has not yet been built
 		importTestProject(testProj.getLocation());
-		
+
 		IJavaProject project = getJavaProject(projectName);
 		dumpJavaProjectInfo(project);
-		
+
 		assertProjects("quickstart");
-		
+
 		assertJarEntry(project, "commons-collections-3.2.jar", true);
 		assertJarEntry(project, "junit-4.12.jar", true);
-		
+
 		assertNoRawLibraryEntries(project);
-//		assertJarEntry(project, "bogus-4.8.2.jar", true);
+		//		assertJarEntry(project, "bogus-4.8.2.jar", true);
 	}
 
-    /**
+	/**
 	 * Verify that project classpath does not have plain jar entries on it (all jars are managed in classpath containers).
-	 * @throws JavaModelException 
+	 * @throws JavaModelException
 	 */
 	public static void assertNoRawLibraryEntries(IJavaProject project) throws JavaModelException {
 		IClasspathEntry[] classpath = project.getRawClasspath();
@@ -650,14 +650,14 @@ public class GradleImportTests extends GradleTest {
 
 	/**
 	 * Executes the gradle 'eclipse' task on project associated with given folder.
-	 * @throws CoreException 
-	 * @throws OperationCanceledException 
+	 * @throws CoreException
+	 * @throws OperationCanceledException
 	 */
 	private void generateEclipseFiles(GradleProject project) throws OperationCanceledException, CoreException {
 		String taskPath = ":eclipse";
 		Set<String> tasks = project.getAllTasks(new NullProgressMonitor());
 		assertTrue(tasks.contains(taskPath));
-		
+
 		ILaunchConfigurationWorkingCopy launchConf = (ILaunchConfigurationWorkingCopy) GradleLaunchConfigurationDelegate.createDefault(project, false);
 		GradleLaunchConfigurationDelegate.setTasks(launchConf, Arrays.asList(taskPath));
 		GradleProcess process = LaunchUtil.synchLaunch(launchConf);
@@ -666,20 +666,20 @@ public class GradleImportTests extends GradleTest {
 	}
 
 	public void testSts1907RemoveReferencedLibraries() throws Exception {
-//		GradleClassPathContainer.DEBUG = true;
+		//		GradleClassPathContainer.DEBUG = true;
 		String name = "quickstart";
 		importSampleProject(name);
 		IJavaProject project = getJavaProject(name);
-		
+
 		dumpJavaProjectInfo(project);
-		
+
 		assertProjects(name);
-		
+
 		assertJarEntry(project, "commons-collections-3.2.jar", true);
 		assertJarEntry(project, "junit-4.12.jar", true);
-//		assertJarEntry(project, "bogus-4.8.2.jar", true);
+		//		assertJarEntry(project, "bogus-4.8.2.jar", true);
 	}
-	
+
 	private void dumpJavaProjectInfo(IJavaProject project) throws CoreException {
 		System.out.println(">>>> JavaProject: "+project.getElementName());
 		String[] natures = project.getProject().getDescription().getNatureIds();
@@ -701,7 +701,7 @@ public class GradleImportTests extends GradleTest {
 	public void testImportJavaMultiProject() throws Exception {
 		do_testImportJavaMultiProject("multiproject");
 	}
-	
+
 	public void do_testImportJavaMultiProject(String rootProjName) throws Exception {
 		String[] projectNames = {
 				rootProjName,
@@ -712,55 +712,55 @@ public class GradleImportTests extends GradleTest {
 				"shared"
 		};
 		IJavaProject rootProject = getJavaProject(projectNames[0]);
-		
+
 		importSampleProject(projectNames[0]);
-		
+
 		assertProjects(
 				projectNames
-		);
-		
+				);
+
 		IJavaProject shared = getJavaProject("shared");
 		assertSourceFolder(shared, "src/main/java");
 		assertSourceFolder(shared, "src/main/resources");
 		assertSourceFolder(shared, "src/test/java");
 		assertSourceFolder(shared, "src/test/resources");
-		
+
 		//Check that every eclipse project has been properly setup to have an association to
 		//a root project.
 		File rootLocation = GradleCore.create(rootProject).getLocation();
 		for (String projectName : projectNames) {
 			GradleProject project = getGradleProject(projectName);
-			
+
 			File actualRootLocation = project.getProjectPreferences().getRootProjectLocation();
 			assertEquals("Root associated with "+project, rootLocation, actualRootLocation);
-			
+
 			//Also check that we can still get it via getRootProject.
 			actualRootLocation = project.getRootProject().getLocation();
 			assertEquals("Root associated with "+project, rootLocation, actualRootLocation);
-			
+
 			//Also check that we can still get it, even if preference is not set
 			project.getProjectPreferences().setRootProjectLocation(null);
 			actualRootLocation = project.getRootProject().getLocation();
 			assertEquals("Root associated with "+project, rootLocation, actualRootLocation);
-			
+
 		}
 	}
-		
+
 	public void testNonExportedDependencies() throws Exception {
 		GradlePreferences prefs = GradleCore.getInstance().getPreferences();
 		prefs.setExportDependencies(false);
 		prefs.setUseCustomToolingModel(true);
 		importTestProject("non-exported-deps");
-		
+
 		assertContainerExported(false, getGradleProject("lib"));
-		
+
 		// Custom model will not be built as early as the legacy model because it
 		// is only used for classpath infos. Thus the first time the model is needed
 		// will be when projects get built (and classpath container is being initialized).
 		// So before verifying that projects build without errors we must wait for
 		// classpath containers to become populated with expected elements
 		new ACondition("check resolved classpaths") {
-			
+
 			@Override
 			public boolean test() throws Exception {
 				assertClasspathJarEntry("commons-collections-3.2.1.jar", getGradleProject("main"));
@@ -769,66 +769,66 @@ public class GradleImportTests extends GradleTest {
 				return true;
 			}
 		}.waitFor(80000);
-		
+
 		assertProjects("non-exported-deps", "main", "lib");
 	}
-	
+
 	public void disabledTestTimedImport() throws Exception {
 		setSnapshotDistro();
-		final GradleImportOperation importOp = importGitProjectOperation(new GitProject("spring-security", 
+		final GradleImportOperation importOp = importGitProjectOperation(new GitProject("spring-security",
 				new URI("git://git.springsource.org/spring-security/spring-security.git"),
 				"359bd7c46")
-		);
-		
+				);
+
 		importOp.excludeProjects(
-				"itest-context", 
-				"itest-web", 
-				"manual", 
-				"docs", 
-				"faq", 
+				"itest-context",
+				"itest-web",
+				"manual",
+				"docs",
+				"faq",
 				"spring-security"
-		);
-		
+				);
+
 		List<Long> times = new ArrayList<Long>();
-		
+
 		for (int i = 0; i < 3; i++) {
 			long startTime = System.currentTimeMillis();
 			performImport(importOp);
 			long endTime = System.currentTimeMillis();
 			times.add(endTime-startTime);
-			
+
 			IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
 			for (IProject proj : projects) {
 				System.out.println(proj);
 			}
-			
+
 			assertProjects(
-					"spring-security-acl", 
-					"spring-security-aspects", 
-					"spring-security-cas", 
-					"spring-security-config", 
-					"spring-security-core", 
-					"spring-security-crypto", 
-					"spring-security-ldap", 
-					"spring-security-openid", 
-					"spring-security-remoting", 
-					"spring-security-samples-aspectj", 
-					"spring-security-samples-cassample", 
-					"spring-security-samples-casserver", 
-					"spring-security-samples-contacts", 
-					"spring-security-samples-dms", 
-					"spring-security-samples-gae", 
-					"spring-security-samples-jaas", 
-					"spring-security-samples-ldap", 
-					"spring-security-samples-openid", 
-					"spring-security-samples-preauth", 
-					"spring-security-samples-tutorial", 
-					"spring-security-taglibs", 
+					"spring-security-acl",
+					"spring-security-aspects",
+					"spring-security-cas",
+					"spring-security-config",
+					"spring-security-core",
+					"spring-security-crypto",
+					"spring-security-ldap",
+					"spring-security-openid",
+					"spring-security-remoting",
+					"spring-security-samples-aspectj",
+					"spring-security-samples-cassample",
+					"spring-security-samples-casserver",
+					"spring-security-samples-contacts",
+					"spring-security-samples-dms",
+					"spring-security-samples-gae",
+					"spring-security-samples-jaas",
+					"spring-security-samples-ldap",
+					"spring-security-samples-openid",
+					"spring-security-samples-preauth",
+					"spring-security-samples-tutorial",
+					"spring-security-taglibs",
 					"spring-security-web"
-			);
-			
+					);
+
 			assertTrue(WTPUtil.isWTPProject(getProject("spring-security-samples-jaas")));
-			
+
 			getGradleProject("spring-security-acl").invalidateGradleModel();
 			ISchedulingRule buildRule = ResourcesPlugin.getWorkspace().getRuleFactory().buildRule();
 			Job.getJobManager().beginRule(buildRule, new NullProgressMonitor());
@@ -838,7 +838,7 @@ public class GradleImportTests extends GradleTest {
 				}
 			} finally {
 				Job.getJobManager().endRule(buildRule);
-				
+
 			}
 		}
 		System.out.println(">>>> import times ====");
@@ -853,17 +853,17 @@ public class GradleImportTests extends GradleTest {
 	}
 
 	public void setSnapshotDistro() {
-// Disabled for now... we won't be running 'integration' style tests anymore. The Gradle guys don't
-// really seem to care about the test failures or bugs I've raised about them. We'll just run tests
-// now with the versions that are supposed to be used with the various test projects.
-		
-//		GradleProperties props = GradleCore.getInstance().getProperties();
-//		if (props.isSnapshot()) {
-//			URI distro =  props.getDistribution();
-//			if (distro!=null) {
-//				GradleCore.getInstance().getPreferences().setDistribution(distro);
-//			}
-//		}
+		// Disabled for now... we won't be running 'integration' style tests anymore. The Gradle guys don't
+		// really seem to care about the test failures or bugs I've raised about them. We'll just run tests
+		// now with the versions that are supposed to be used with the various test projects.
+
+		//		GradleProperties props = GradleCore.getInstance().getProperties();
+		//		if (props.isSnapshot()) {
+		//			URI distro =  props.getDistribution();
+		//			if (distro!=null) {
+		//				GradleCore.getInstance().getPreferences().setDistribution(distro);
+		//			}
+		//		}
 	}
 
 	/**
@@ -873,36 +873,36 @@ public class GradleImportTests extends GradleTest {
 	public void testImportProjectWithLinkedResource() throws Exception {
 		String projectName = "multiproject";
 		String subprojectName = "subproject";
-		
+
 		importTestProject(projectName);
-		
+
 		assertProjects(
 				projectName,
 				subprojectName);
-		
+
 		//Check whether the 'Main' type whose source code is actually inside of the parent project, but on the
 		//source path of the subproject is actually found in the subproject.
-		
+
 		IJavaProject subproject = getJavaProject(subprojectName);
 		assertNotNull(subproject);
 		IType mainType = subproject.findType("Main");
 		assertNotNull(mainType);
-		
+
 		mainType = subproject.findType("Spain");
 		assertNull(mainType);
-		
+
 		//Next check whether after editing the build.gradle file the linked source folders
 		//are updated by a refresh source folders.
-		
-		createFile(subproject.getProject(), "build.gradle", 
-				"sourceSets {\n" + 
-				"	main {\n" + 
-				"		java {\n" + 
-				"			srcDir '../boink2'\n" + 
-				"		}\n" + 
-				"	}\n" + 
+
+		createFile(subproject.getProject(), "build.gradle",
+				"sourceSets {\n" +
+						"	main {\n" +
+						"		java {\n" +
+						"			srcDir '../boink2'\n" +
+						"		}\n" +
+						"	}\n" +
 				"}");
-		
+
 		GradleProject gSubproject = getGradleProject(subprojectName);
 		gSubproject.invalidateGradleModel();
 		gSubproject.refreshSourceFolders(new ErrorHandler.Test(), new NullProgressMonitor());
@@ -912,11 +912,11 @@ public class GradleImportTests extends GradleTest {
 		assertNull(mainType);
 		mainType = subproject.findType("Spain");
 		assertNotNull(mainType);
-		
+
 		//Re-refreshing should not be a problem...
 		gSubproject.invalidateGradleModel();
 		gSubproject.refreshSourceFolders(new ErrorHandler.Test(), new NullProgressMonitor());
-		
+
 		//Nothing changed, should still pass the same assertions
 		mainType = subproject.findType("Main");
 		assertNull(mainType);
@@ -931,28 +931,28 @@ public class GradleImportTests extends GradleTest {
 	public void testWithMultipleLinkedResources() throws Exception {
 		String projectName = "multiproject";
 		String subprojectName = "subproject";
-		
+
 		importTestProject(projectName);
-		
+
 		assertProjects(
 				projectName,
 				subprojectName);
-		
+
 		IJavaProject subproject = getJavaProject(subprojectName);
-		createFile(subproject.getProject(), "build.gradle", 
-				"sourceSets {\n" + 
-				"	main {\n" + 
-				"		java {\n" + 
-				"			srcDir '../boink'\n" + 
-				"			srcDir '../boink2'\n" + 
-				"		}\n" + 
-				"	}\n" + 
+		createFile(subproject.getProject(), "build.gradle",
+				"sourceSets {\n" +
+						"	main {\n" +
+						"		java {\n" +
+						"			srcDir '../boink'\n" +
+						"			srcDir '../boink2'\n" +
+						"		}\n" +
+						"	}\n" +
 				"}");
-		
+
 		GradleProject gSubproject = getGradleProject(subprojectName);
 		gSubproject.invalidateGradleModel();
 		gSubproject.refreshSourceFolders(new ErrorHandler.Test(), new NullProgressMonitor());
-		
+
 		//This time, both of the main types should be found since we added both source folders.
 		assertNotNull(subproject);
 		IType mainType = subproject.findType("Main");
@@ -960,7 +960,7 @@ public class GradleImportTests extends GradleTest {
 		mainType = subproject.findType("Spain");
 		assertNotNull(mainType);
 	}
-	
+
 	public void testSTS2175ClassPathEntryOrder() throws Exception {
 		String[] projectNames = {
 				"sts2175",
@@ -978,50 +978,50 @@ public class GradleImportTests extends GradleTest {
 		}
 		GradleProject gp = getGradleProject("suba");
 		IJavaProject jp = gp.getJavaProject();
-		
-		String bThenC = "dependencies {\n" + 
-		"	compile project(':subb')\n" + 
-		"	compile project(':subc')\n" + 
-		"}";
-		String cThenB = "dependencies {\n" + 
-		"	compile project(':subc')\n" + 
-		"	compile project(':subb')\n" + 
-		"}";
+
+		String bThenC = "dependencies {\n" +
+				"	compile project(':subb')\n" +
+				"	compile project(':subc')\n" +
+				"}";
+		String cThenB = "dependencies {\n" +
+				"	compile project(':subc')\n" +
+				"	compile project(':subb')\n" +
+				"}";
 
 		createFile(getProject("suba"),"build.gradle", bThenC);
 		refreshDependencies(getProject("suba"));
-		
+
 		assertSts2175ExpectedCP(
-				"subb", "subc", 
+				"subb", "subc",
 				gp.getClassPathcontainer().getClasspathEntries());
-		
+
 		createFile(getProject("suba"),"build.gradle", cThenB); //Build script order changed!!
 		refreshDependencies(getProject("suba"));
 		assertSts2175ExpectedCP(
 				"subb", "subc", //Classpath order same (is sorted!)
 				gp.getClassPathcontainer().getClasspathEntries());
-		
+
 		//Now disable sorting... the ordering should change
-		gp.getProjectPreferences().setEnableClasspatEntrySorting(false);
+		gp.getProjectPreferences().setEnableClasspathEntrySorting(false);
 		for (String name : projectNames) {
 			//Setting this should affect all projects in the hierarchy
 			GradleProject p = getGradleProject(name);
 			assertEquals(false, p.getProjectPreferences().getEnableClasspathEntrySorting());
 		}
-		
-		
+
+
 		refreshDependencies(getProject("suba"));
 		assertSts2175ExpectedCP(
 				"subc", "subb", //Classpath order same (is sorted!)
 				gp.getClassPathcontainer().getClasspathEntries());
-		
+
 		createFile(getProject("suba"),"build.gradle", bThenC); //Order changed
 		refreshDependencies(getProject("suba"));
 		assertSts2175ExpectedCP(
 				"subb", "subc", //Classpath order same (is sorted!)
 				gp.getClassPathcontainer().getClasspathEntries());
 	}
-	
+
 	public void testSTS3742ClassPathContainerEntryOrder() throws Exception {
 		setAutoBuilding(false);
 		importTestProject("sts3742");
@@ -1029,26 +1029,27 @@ public class GradleImportTests extends GradleTest {
 
 		GradleProject gp = getGradleProject("sts3742");
 		IJavaProject jp = gp.getJavaProject();
-		
+
 		assertWtpAfterGradleDependencies(jp);
-		
-		gp.getProjectPreferences().setEnableClasspatEntrySorting(false);
+
+		gp.getProjectPreferences().setEnableClasspathEntrySorting(false);
 		reimport(gp);
 		assertWtpAfterGradleDependencies(jp);
-		
-		gp.getProjectPreferences().setEnableClasspatEntrySorting(true);
+
+		gp.getProjectPreferences().setEnableClasspathEntrySorting(true);
 		reimport(gp);
-		assertWtpAfterGradleDependencies(jp);		
+		assertWtpAfterGradleDependencies(jp);
 	}
 
 	public static void reimport(final GradleProject gp) throws Exception {
 		JobUtil.withRule(JobUtil.buildRule(), new NullProgressMonitor(), 1, new GradleRunnable("Reimport "+gp.getDisplayName()) {
+			@Override
 			public void doit(IProgressMonitor mon) throws Exception {
 				new ReimportOperation(Collections.singletonList(gp)).perform(null, new NullProgressMonitor());
 			}
 		});
 	}
-	
+
 	private static void assertWtpAfterGradleDependencies(IJavaProject jp) throws JavaModelException {
 		int wtpIndex = -1;
 		int gradleDepIndex = -1;
@@ -1061,13 +1062,13 @@ public class GradleImportTests extends GradleTest {
 				wtpIndex = i;
 			}
 		}
-		
+
 		assertTrue("Web App Libraries container is missing", wtpIndex >= 0);
 		assertTrue("Gradle Dependencies container is missing", gradleDepIndex >= 0);
 		assertTrue("Gradle Dependencies container is located after the Web App Libraries container on the classpath!", wtpIndex > gradleDepIndex);
 	}
 
-	
+
 	private void dumpRawClasspath(IJavaProject jp) throws JavaModelException {
 		System.out.println(">>> raw classpath for "+jp.getElementName());
 		for (IClasspathEntry e : jp.getRawClasspath()) {
@@ -1083,10 +1084,10 @@ public class GradleImportTests extends GradleTest {
 			j.join();
 		}
 	}
-	
+
 	public static class WaitForRefresh extends ACondition implements IRefreshListener {
 		private boolean refreshed = false;
-		
+
 		@Override
 		public void classpathContainerRefreshed() {
 			refreshed = true;
@@ -1117,17 +1118,17 @@ public class GradleImportTests extends GradleTest {
 		gui.location.setValue(SampleProject.getDefaultProjectLocation(gui.name.getValue()));
 		gui.sampleProject.setValue(SampleProjectRegistry.getInstance().get("flat-java-multiproject"));
 		gui.newProjectOp.perform(new NullProgressMonitor());
-		
+
 		assertProjects("flat-parent", "my-lib", "product");
-		
+
 		GradleProject gp = GradleCore.create(getProject("product"));
 		assertTrue(gp.isDependencyManaged());
 		assertClasspathProjectEntry(getProject("my-lib"), gp.getJavaProject());
-		
+
 		assertNoExplicitProjectEntries(gp.getJavaProject());
 	}
-	
+
 	//TODO: under what circumstances will linked resources returned by gradle api refer to files (not folders)?
 	// We don't have a test for this situation so the code that supports it has never been run.
-	
+
 }

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ClassPath.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ClassPath.java
@@ -36,7 +36,7 @@ import org.springsource.ide.eclipse.gradle.core.classpathcontainer.GradleClassPa
  * @author Kris De Volder
  */
 public class ClassPath {
-	
+
 	public static boolean isContainerOnClasspath(IJavaProject jp, String containerID) {
 		try {
 			IClasspathEntry[] entries = jp.getRawClasspath();
@@ -53,15 +53,15 @@ public class ClassPath {
 		}
 		return false;
 	}
-	
+
 	public boolean DEBUG = false;
-	
+
 	private void debug(String msg) {
 		if (DEBUG) {
 			System.out.println("ClassPath: "+msg);
 		}
 	}
-	
+
 	/**
 	 * This array defines the ordering classpath entries based on their kinds.
 	 */
@@ -72,14 +72,15 @@ public class ClassPath {
 		IClasspathEntry.CPE_VARIABLE,
 		IClasspathEntry.CPE_PROJECT
 	};
-	
+
 	/**
 	 * Entries, divided-up by category so that categories always maintain their order no matter
 	 * what order entries are added in.
 	 */
-	private Map<Integer, Collection<IClasspathEntry>> entryMap = new HashMap<Integer, Collection<IClasspathEntry>>(kindOrdering.length);
+	private final Map<Integer, Collection<IClasspathEntry>> entryMap = new HashMap<Integer, Collection<IClasspathEntry>>(kindOrdering.length);
 
 	public class ClasspathEntryComparator implements Comparator<IClasspathEntry> {
+		@Override
 		public int compare(IClasspathEntry e1, IClasspathEntry e2) {
 			int k1 = e1.getEntryKind();
 			int k2 = e2.getEntryKind();
@@ -104,33 +105,49 @@ public class ClassPath {
 					str = "AA";
 				} else if (str.startsWith("GROOVY_")) {
 					//STS-3382: DSL support Groovy container should be last entry on classpath
-					str = "zzz"+str; 
+					str = "zzz"+str;
 				}
 			}
 			return str;
 		}
 	}
 
-	private boolean enableSorting; //If true, entries of the same kind will be sorted otherwise they will retained in the order they are being added.
+	public class ClassnameEntryComparator implements Comparator<IClasspathEntry> {
+		@Override
+		public int compare(IClasspathEntry e1, IClasspathEntry e2) {
+			int k1 = e1.getEntryKind();
+			int k2 = e2.getEntryKind();
+			Assert.isLegal(k1==k2, "Only entries with the same kind should be compared");
+			String p1 = e1.getPath().lastSegment().toLowerCase();
+			String p2 = e2.getPath().lastSegment().toLowerCase();
+			return p1.compareTo(p2);
+		}
+	}
 
-	/** 
+	private final boolean enablePathSorting; //If true, entries of the same kind will be sorted otherwise they will retained in the order they are being added.
+	private final boolean enableNameSorting; //If true, entries of the same kind will be sorted otherwise they will retained in the order they are being added.
+
+	/**
 	 * Create a classpath prepopoluated with a set of raw classpath entries.
-	 * 
-	 * @param project 
+	 *
+	 * @param project
 	 * @param i
 	 */
 	public ClassPath(GradleProject project, IClasspathEntry[] rawEntries) {
 		this(project);
 		addAll(Arrays.asList(rawEntries));
 	}
-	
+
 	public ClassPath(GradleProject project) {
-		this.enableSorting = project.getProjectPreferences().getEnableClasspathEntrySorting();
+		enablePathSorting = project.getProjectPreferences().getEnableClasspathEntrySorting();
+		enableNameSorting = project.getProjectPreferences().getEnableClassnameEntrySorting();
 	}
 
 	public Collection<IClasspathEntry> createEntrySet(int size) {
-		if (enableSorting) {
+		if (enablePathSorting) {
 			return new TreeSet<IClasspathEntry>(new ClasspathEntryComparator());
+		} else if (enableNameSorting) {
+			return new TreeSet<IClasspathEntry>(new ClassnameEntryComparator());
 		} else {
 			return new LinkedHashSet<IClasspathEntry>();
 		}
@@ -155,7 +172,7 @@ public class ClassPath {
 			}
 		}
 	}
-	
+
 	/**
 	 * Retrieves the classpath entries of a particular kind only.
 	 */
@@ -174,7 +191,7 @@ public class ClassPath {
 	public void removeLibraryEntries() {
 		entryMap.remove(IClasspathEntry.CPE_LIBRARY);
 	}
-	
+
 	/**
 	 * Removes all project entries from this classpath.
 	 */
@@ -209,10 +226,10 @@ public class ClassPath {
 	}
 
 	/**
-	 * Find class path container entry with given container ID. If more than one entry 
+	 * Find class path container entry with given container ID. If more than one entry
 	 * exists the first one found will be returned. If no entry is found null will be
 	 * returned.
-	 * 
+	 *
 	 * @param containerID
 	 * @return First matching classpath entry or null if no match.
 	 */
@@ -225,7 +242,7 @@ public class ClassPath {
 		}
 		return null;
 	}
-	
+
 	public void removeContainer(String containerID) {
 		Collection<IClasspathEntry> containers = getEntries(IClasspathEntry.CPE_CONTAINER);
 		Iterator<IClasspathEntry> iter = containers.iterator();
@@ -236,7 +253,7 @@ public class ClassPath {
 			}
 		}
 	}
-	
+
 	private boolean isJREContainer(IClasspathEntry e) {
 		return isContainer(e, JavaRuntime.JRE_CONTAINER);
 	}
@@ -278,8 +295,9 @@ public class ClassPath {
 	}
 
 	private boolean isChanged(IClasspathEntry[] oldClasspath, IClasspathEntry[] newClasspath) {
-		if (oldClasspath.length!=newClasspath.length) 
+		if (oldClasspath.length!=newClasspath.length) {
 			return true;
+		}
 		for (int i = 0; i < newClasspath.length; i++) {
 			if (!oldClasspath[i].equals(newClasspath[i])) {
 				return true;

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradleProjectPreferences.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradleProjectPreferences.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.Platform;
 import org.springsource.ide.eclipse.gradle.core.GradleCore;
 import org.springsource.ide.eclipse.gradle.core.GradleProject;
 import org.springsource.ide.eclipse.gradle.core.classpathcontainer.FastOperationFailedException;
@@ -27,14 +26,12 @@ import org.springsource.ide.eclipse.gradle.core.util.ResourceListEncoder;
  * <p>
  * Also used to store other persisted properties associated with a project, that should be stored in
  * the files associated with the project (inside the .settings folder).
- * 
+ *
  * @author Kris De Volder
  */
 public class GradleProjectPreferences extends AbstractGradleProjectPreferences {
-	
+
 	private static final boolean DEBUG = false;
-//		=  (""+Platform.getLocation()).contains("kdvolder")
-//		|| (""+Platform.getLocation()).contains("bamboo");
 
 	private void debug(String string) {
 		if (DEBUG) {
@@ -45,12 +42,14 @@ public class GradleProjectPreferences extends AbstractGradleProjectPreferences {
 	private static final String LINKED_RESOURCES_PREF = "org.springsource.ide.eclipse.gradle.linkedresources";
 	private static final String ROOT_LOCATION_PREF = "org.springsource.ide.eclipse.gradle.rootprojectloc";
 	private static final String ENABLE_CLASSPATH_SORTING = "org.springsource.ide.eclipse.gradle.classpath.enableSorting";
-	
-	public static final boolean DEFAULT_ENABLE_CLASSPATH_SORTING = true; 
-	
+	private static final String ENABLE_CLASSNAME_SORTING = "org.springsource.ide.eclipse.gradle.classname.enableSorting";
+
+	public static final boolean DEFAULT_ENABLE_CLASSPATH_SORTING = false;
+	public static final boolean DEFAULT_ENABLE_CLASSNAME_SORTING = true;
+
 	/**
 	 * Get preferences associated with this project.
-	 *  
+	 *
 	 * @param project
 	 */
 	public GradleProjectPreferences(GradleProject project) {
@@ -79,7 +78,7 @@ public class GradleProjectPreferences extends AbstractGradleProjectPreferences {
 	public File getRootProjectLocation() {
 		return get(ROOT_LOCATION_PREF, (File)null);
 	}
-		
+
 	/**
 	 * @return Whether classpath entry sorting is enabled. This preference is shared by all projects in a project hierarchy.
 	 */
@@ -88,20 +87,50 @@ public class GradleProjectPreferences extends AbstractGradleProjectPreferences {
 			AbstractGradleProjectPreferences rootPrefs = getRootProjectPreferences();
 			return rootPrefs.get(ENABLE_CLASSPATH_SORTING, DEFAULT_ENABLE_CLASSPATH_SORTING);
 		} catch (FastOperationFailedException e) {
-			GradleCore.log(e); 
+			GradleCore.log(e);
 			return DEFAULT_ENABLE_CLASSPATH_SORTING;
 		}
 	}
-	
-	public void setEnableClasspatEntrySorting(boolean enable) {
+
+	public void setEnableClasspathEntrySorting(boolean enable) {
 		try {
 			AbstractGradleProjectPreferences rootPrefs = getRootProjectPreferences();
 			rootPrefs.put(ENABLE_CLASSPATH_SORTING, enable);
 		} catch (FastOperationFailedException e) {
-			GradleCore.log(e); 
+			GradleCore.log(e);
 		}
 	}
-	
+
+	/**
+	 * @return Whether classname entry sorting is enabled. This preference is shared by all projects in a project hierarchy.
+	 */
+	public boolean getEnableClassnameEntrySorting()
+	{
+		try
+		{
+			AbstractGradleProjectPreferences rootPrefs = getRootProjectPreferences();
+			return rootPrefs.get(ENABLE_CLASSNAME_SORTING, DEFAULT_ENABLE_CLASSNAME_SORTING);
+		}
+		catch (FastOperationFailedException e)
+		{
+			GradleCore.log(e);
+			return DEFAULT_ENABLE_CLASSNAME_SORTING;
+		}
+	}
+
+	public void setEnableClassnameEntrySorting(boolean enable)
+	{
+		try
+		{
+			AbstractGradleProjectPreferences rootPrefs = getRootProjectPreferences();
+			rootPrefs.put(ENABLE_CLASSNAME_SORTING, enable);
+		}
+		catch (FastOperationFailedException e)
+		{
+			GradleCore.log(e);
+		}
+	}
+
 	public File getJavaHome() {
 		//Presently this preference can not be specified on projects so we just use the
 		//global preference to determine it.

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleProjectPropertyPage.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleProjectPropertyPage.java
@@ -28,18 +28,19 @@ import org.springsource.ide.eclipse.gradle.core.preferences.GradleProjectPrefere
 
 /**
  * For setting preferences that are associated with a Gradle 'build'. These preferences/properties
- * are stored at the root of a project hierarchy. 
+ * are stored at the root of a project hierarchy.
  * <p>
- * Eclipse has no concept where a group of projects share some common preferences / settings. 
+ * Eclipse has no concept where a group of projects share some common preferences / settings.
  * So we implement this as a project property page. But bo matter which project in a hierachy
  * the page is opened on, it will always store/fetch properties in the root project associated
  * with that project.
- * 
+ *
  * @author Kris De Volder
  */
 public class GradleProjectPropertyPage extends PropertyPage implements IWorkbenchPropertyPage {
-	
-	private Button enableSortingButton;
+
+	private Button enablePathSortingButton;
+	private Button enableNameSortingButton;
 
 	public GradleProjectPropertyPage() {
 		super();
@@ -47,43 +48,50 @@ public class GradleProjectPropertyPage extends PropertyPage implements IWorkbenc
 
 	@Override
 	protected Control createContents(Composite parent) {
-        GridDataFactory grabHorizontal = GridDataFactory.fillDefaults().grab(true, false);
-        GridDataFactory grabBoth = GridDataFactory.fillDefaults().grab(true, true);
-        
+		GridDataFactory grabHorizontal = GridDataFactory.fillDefaults().grab(true, false);
+		GridDataFactory grabBoth = GridDataFactory.fillDefaults().grab(true, true);
+
 		Composite page = new Composite(parent, SWT.NONE);
-        GridLayout layout = new GridLayout(1, false);
-        layout.marginHeight = 1;
-        layout.marginWidth = 1;
-        page.setLayout(layout);
-        grabBoth.applyTo(page);
-        
-        GradleProject project = getGradleProject();
-        if (project==null) {
-        	Label errorMsg = new Label(page, SWT.WRAP);
-        	errorMsg.setText("Can't open Gradle project preferences: No project selected");
-        } else {
-            Group group1 = new Group(page, SWT.BORDER);
-            grabHorizontal.applyTo(group1);
-            group1.setText("Classpath sorting strategy");
-            group1.setLayout(new GridLayout(2, true));
-            enableSortingButton = new Button(group1, SWT.RADIO);
-            enableSortingButton.setText("Alphabetically by path");
-            Button disableSortingButton = new Button(group1, SWT.RADIO);
-            disableSortingButton.setText("As returned by build script");
-            if (project.getProjectPreferences().getEnableClasspathEntrySorting()) {
-            	enableSortingButton.setSelection(true);
-            } else {
-            	disableSortingButton.setSelection(true);
-            }
-        }
-        return page;
+		GridLayout layout = new GridLayout(1, false);
+		layout.marginHeight = 1;
+		layout.marginWidth = 1;
+		page.setLayout(layout);
+		grabBoth.applyTo(page);
+
+		GradleProject project = getGradleProject();
+		if (project==null) {
+			Label errorMsg = new Label(page, SWT.WRAP);
+			errorMsg.setText("Can't open Gradle project preferences: No project selected");
+		} else {
+			Group group1 = new Group(page, SWT.BORDER);
+			grabHorizontal.applyTo(group1);
+			group1.setText("Dependency sorting strategy");
+			group1.setLayout(new GridLayout(3, true));
+			enableNameSortingButton = new Button(group1, SWT.RADIO);
+			enableNameSortingButton.setText("Alphabetically by name");
+			enablePathSortingButton = new Button(group1, SWT.RADIO);
+			enablePathSortingButton.setText("Alphabetically by path");
+			Button disableSortingButton = new Button(group1, SWT.RADIO);
+			disableSortingButton.setText("As returned by build script");
+			if (project.getProjectPreferences().getEnableClasspathEntrySorting()) {
+				enablePathSortingButton.setSelection(true);
+			}
+			else if (project.getProjectPreferences().getEnableClassnameEntrySorting()) {
+				enableNameSortingButton.setSelection(true);
+			}
+			else {
+				disableSortingButton.setSelection(true);
+			}
+		}
+		return page;
 	}
 
 	@Override
 	public boolean performOk() {
 		GradleProject gradleProject = getGradleProject();
 		GradleProjectPreferences prefs = gradleProject.getProjectPreferences();
-		prefs.setEnableClasspatEntrySorting(enableSortingButton.getSelection());
+		prefs.setEnableClasspathEntrySorting(enablePathSortingButton.getSelection());
+		prefs.setEnableClassnameEntrySorting(enableNameSortingButton.getSelection());
 		return true;
 	}
 


### PR DESCRIPTION
Added a new option to sort the dependencies by their names rather than the whole class paths.
This update is related to this discussion -
https://github.com/spring-projects/eclipse-integration-gradle/issues/2