### PR TITLE
URL Cleanup

### DIFF
--- a/docs/convert.sh
+++ b/docs/convert.sh
@@ -3,8 +3,8 @@ echo "<html><head>"
 echo "<link rel=\"stylesheet\" href=\"css/stylesheet.css\" type=\"text/css\">"
 echo "<title>Gradle STS Tooling Docs</title>"
 echo "</head><body>"
-#echo "<a href=\"http://springsource.com/developer/sts\"><img style=\"border: 0px solid ; height: 60px; width: 60px;\" alt=\"logo\" src=\"img/sts60x60.png\" align=\"left\"></a>"
-#echo "<a href=\"http://www.springsource.com/\"><img style=\"border: 0px solid ; width: 240px; height: 50px;\" alt=\"logo\" src=\"img/spring09_logo.png\" align=\"right\"></a>"
+#echo "<a href=\"https://springsource.com/developer/sts\"><img style=\"border: 0px solid ; height: 60px; width: 60px;\" alt=\"logo\" src=\"img/sts60x60.png\" align=\"left\"></a>"
+#echo "<a href=\"https://www.springsource.com/\"><img style=\"border: 0px solid ; width: 240px; height: 50px;\" alt=\"logo\" src=\"img/spring09_logo.png\" align=\"right\"></a>"
 markdown $1
 echo "</body></html>"
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<connection>scm:git:ssh://github.com/SpringSource/eclipse-integration-gradle.git</connection>
 		<developerConnection>scm:git:ssh:git@github.com:SpringSource/eclipse-integration-tcserver.git</developerConnection>
 		<tag>HEAD</tag>
-		<url>http://git.springsource.com/sts/sts</url>
+		<url>https://git.springsource.com/sts/sts</url>
 	</scm>
 
 	<modules>
@@ -31,9 +31,9 @@
 
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
-	<url>http://spring.io/tools</url>
+	<url>https://spring.io/tools</url>
 
 	<prerequisites>
 		<maven>3.0</maven>
@@ -129,27 +129,27 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/3.7/</url>
+					<url>https://download.eclipse.org/eclipse/updates/3.7/</url>
 				</repository>
 				<repository>
 					<id>indigo</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/indigo/</url>
+					<url>https://download.eclipse.org/releases/indigo/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
+					<url>https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
 				</repository>
 				<repository>
 					<id>greclipse37</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.org/snapshot/GRECLIPSE/e3.7/</url>
+					<url>https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
 				</repository>
 
 			</repositories>
@@ -169,32 +169,32 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.2/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.2/</url>
 				</repository>
 				<repository> 
 					<id>indigo</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/indigo/</url>
+					<url>https://download.eclipse.org/releases/indigo/</url>
 				</repository>
 				<repository>
 					<id>juno</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/juno/</url>
+					<url>https://download.eclipse.org/releases/juno/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
+					<url>https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
 				</repository>
 				<repository>
 					<id>greclipse42</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.2/</url>
+					<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
 				</repository>
 
 			</repositories>
@@ -214,27 +214,27 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.3/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.3/</url>
 				</repository>
 				<repository> 
 					<id>kepler</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/kepler/</url>
+					<url>https://download.eclipse.org/releases/kepler/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
+					<url>https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
 				</repository>
 				<repository>
 					<id>greclipse43</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.3/</url>
+					<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
 				</repository>
 
 			</repositories>
@@ -254,27 +254,27 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.4</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.4</url>
 				</repository>
 				 <repository> 
 					<id>luna</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/luna/</url>
+					<url>https://download.eclipse.org/releases/luna/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 					<id>greclipse44</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.4/</url>
+					<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e4.4/</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e4.4/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -293,32 +293,32 @@
 				<repository>
 					<id>platform</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.5</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.5</url>
 				</repository>
 				 <repository> 
 					<id>luna</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/mars/</url>
+					<url>https://download.eclipse.org/releases/mars/</url>
 				</repository>
 				<repository>
 					<id>swtbot</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+					<url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 				</repository>
 				<repository>
 					<id>greclipse44</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/</url>
+					<url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.5/</url>
 				</repository>
 				<repository>
 					<id>eclipse-integration-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}</url>
+					<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}</url>
 				</repository>
 				<repository>
 					<id>buildship</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e45/releases/1.0</url>
+					<url>https://download.eclipse.org/buildship/updates/e45/releases/1.0</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -368,26 +368,26 @@
  		<repository>
  			<id>p2-thirdparty-bundles</id>
  			<layout>p2</layout>
- 			<url>http://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo</url>
+ 			<url>https://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo</url>
  		</repository>
  		
 		<repository>
 			<id>mylyn</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/mylyn/releases/3.7</url>
+			<url>https://download.eclipse.org/mylyn/releases/3.7</url>
 		</repository>
 
 		<repository>
 			<id>m2e-releases</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/technology/m2e/releases/</url>
+			<url>https://download.eclipse.org/technology/m2e/releases/</url>
 		</repository>
 
 		<!-- required for Maven and Ant AWS dependency -->
 		<repository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<!-- required for commons-cli dependency in c.s.sts.grails.core -->
 		<repository>
@@ -396,7 +396,7 @@
 		</repository>
 		<repository>
 			<id>maven-mirror</id>
-			<url>http://repo.exist.com/maven2</url>
+			<url>https://repo.exist.com/maven2</url>
 		</repository>
 	</repositories>
 
@@ -405,12 +405,12 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>tycho-staging</id>

--- a/toolingapi/build.gradle
+++ b/toolingapi/build.gradle
@@ -15,7 +15,7 @@ subprojects {
             url "$projectDir/repo"
         }
 		mavenCentral()
-		maven { url 'http://repo.gradle.org/gradle/libs-releases-local' }
+		maven { url 'https://repo.gradle.org/gradle/libs-releases-local' }
 	}
 	
 	task sourceJar(type: Jar) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://sha256timestamp.ws.symantec.com/sha256/timestamp (400) migrated to:  
  http://sha256timestamp.ws.symantec.com/sha256/timestamp ([https](https://sha256timestamp.ws.symantec.com/sha256/timestamp) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://git.springsource.com/sts/sts (UnknownHostException) migrated to:  
  https://git.springsource.com/sts/sts ([https](https://git.springsource.com/sts/sts) result UnknownHostException).
* http://repo.exist.com/maven2 (UnknownHostException) migrated to:  
  https://repo.exist.com/maven2 ([https](https://repo.exist.com/maven2) result UnknownHostException).
* http://dist.springsource.com/ (403) migrated to:  
  https://dist.springsource.com/ ([https](https://dist.springsource.com/) result 403).
* http://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo (403) migrated to:  
  https://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo ([https](https://dist.springsource.com/release/TOOLS/third-party/misc-p2-repo) result 403).
* http://repository.springsource.com/maven/bundles/release (404) migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://dist.springsource.org/snapshot/GRECLIPSE/e3.7/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.2/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.3/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.4/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.5/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.5/) result 200).
* http://download.eclipse.org/eclipse/updates/3.7/ migrated to:  
  https://download.eclipse.org/eclipse/updates/3.7/ ([https](https://download.eclipse.org/eclipse/updates/3.7/) result 200).
* http://download.eclipse.org/eclipse/updates/4.2/ migrated to:  
  https://download.eclipse.org/eclipse/updates/4.2/ ([https](https://download.eclipse.org/eclipse/updates/4.2/) result 200).
* http://download.eclipse.org/eclipse/updates/4.3/ migrated to:  
  https://download.eclipse.org/eclipse/updates/4.3/ ([https](https://download.eclipse.org/eclipse/updates/4.3/) result 200).
* http://download.eclipse.org/releases/indigo/ migrated to:  
  https://download.eclipse.org/releases/indigo/ ([https](https://download.eclipse.org/releases/indigo/) result 200).
* http://download.eclipse.org/releases/juno/ migrated to:  
  https://download.eclipse.org/releases/juno/ ([https](https://download.eclipse.org/releases/juno/) result 200).
* http://download.eclipse.org/releases/kepler/ migrated to:  
  https://download.eclipse.org/releases/kepler/ ([https](https://download.eclipse.org/releases/kepler/) result 200).
* http://download.eclipse.org/releases/luna/ migrated to:  
  https://download.eclipse.org/releases/luna/ ([https](https://download.eclipse.org/releases/luna/) result 200).
* http://download.eclipse.org/releases/mars/ migrated to:  
  https://download.eclipse.org/releases/mars/ ([https](https://download.eclipse.org/releases/mars/) result 200).
* http://download.eclipse.org/technology/m2e/releases/ migrated to:  
  https://download.eclipse.org/technology/m2e/releases/ ([https](https://download.eclipse.org/technology/m2e/releases/) result 200).
* http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/ migrated to:  
  https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/ ([https](https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/) result 200).
* http://download.eclipse.org/technology/swtbot/releases/latest/ migrated to:  
  https://download.eclipse.org/technology/swtbot/releases/latest/ ([https](https://download.eclipse.org/technology/swtbot/releases/latest/) result 200).
* http://spring.io migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://spring.io/tools migrated to:  
  https://spring.io/tools ([https](https://spring.io/tools) result 200).
* http://download.eclipse.org/buildship/updates/e45/releases/1.0 migrated to:  
  https://download.eclipse.org/buildship/updates/e45/releases/1.0 ([https](https://download.eclipse.org/buildship/updates/e45/releases/1.0) result 301).
* http://download.eclipse.org/eclipse/updates/4.4 migrated to:  
  https://download.eclipse.org/eclipse/updates/4.4 ([https](https://download.eclipse.org/eclipse/updates/4.4) result 301).
* http://download.eclipse.org/eclipse/updates/4.5 migrated to:  
  https://download.eclipse.org/eclipse/updates/4.5 ([https](https://download.eclipse.org/eclipse/updates/4.5) result 301).
* http://download.eclipse.org/mylyn/releases/3.7 migrated to:  
  https://download.eclipse.org/mylyn/releases/3.7 ([https](https://download.eclipse.org/mylyn/releases/3.7) result 301).
* http://www.springsource.com/ migrated to:  
  https://www.springsource.com/ ([https](https://www.springsource.com/) result 301).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://repo.gradle.org/gradle/libs-releases-local migrated to:  
  https://repo.gradle.org/gradle/libs-releases-local ([https](https://repo.gradle.org/gradle/libs-releases-local) result 302).
* http://springsource.com/developer/sts migrated to:  
  https://springsource.com/developer/sts ([https](https://springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance
* http://www.w3.org/TR/html4/strict.dtd