### PR TITLE
URL Cleanup

### DIFF
--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -173,7 +173,7 @@ The Apache Software Foundation (http://www.apache.org/).
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-* http://www.apache.org/licenses/LICENSE-2.0
+* https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -190,7 +190,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -207,7 +207,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -224,7 +224,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -241,7 +241,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -258,7 +258,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -275,7 +275,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -297,7 +297,7 @@ License: Apache 2.0
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -314,7 +314,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -358,7 +358,7 @@ objenesis-1.2-sources.jar\org\objenesis\instantiator\jrockit\JRockit131Instantia
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -398,7 +398,7 @@ Copyright (c) 1997-2005 The Apache Software Foundation. All rights reserved.
 Your use of the Commons IO code is subject to the terms and conditions of the Apache Software License 2.0. A copy of the license is contained in the file 
 LICENSE.txt
  and is also available at 
-http://www.apache.org/licenses/LICENSE-2.0.html
+https://www.apache.org/licenses/LICENSE-2.0.html
 .
 The Apache attribution 
 NOTICE.txt
@@ -535,7 +535,7 @@ The Content includes items that have been sourced from third parties, as set out
 Apache License 
 
 Version 2.0, January 2004 
-http://www.apache.org/licenses/ 
+https://www.apache.org/licenses/ 
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 

--- a/org.springsource.ide.eclipse.gradle.feature/feature.properties
+++ b/org.springsource.ide.eclipse.gradle.feature/feature.properties
@@ -201,7 +201,7 @@ The Apache Software Foundation (http://www.apache.org/).\n\
 * you may not use this file except in compliance with the License.\n\
 * You may obtain a copy of the License at\n\
 *\n\
-* http://www.apache.org/licenses/LICENSE-2.0\n\
+* https://www.apache.org/licenses/LICENSE-2.0\n\
 *\n\
 * Unless required by applicable law or agreed to in writing, software\n\
 * distributed under the License is distributed on an "AS IS" BASIS,\n\
@@ -218,7 +218,7 @@ Licensed under the Apache License, Version 2.0 (the License);\n\
 you may not use this file except in compliance with the License.\n\
 You may obtain a copy of the License at\n\
 \n\
-http://www.apache.org/licenses/LICENSE-2.0\n\
+https://www.apache.org/licenses/LICENSE-2.0\n\
 \n\
 Unless required by applicable law or agreed to in writing, software\n\
 distributed under the License is distributed on an AS IS BASIS,\n\
@@ -235,7 +235,7 @@ Licensed under the Apache License, Version 2.0 (the License);\n\
 you may not use this file except in compliance with the License.\n\
 You may obtain a copy of the License at\n\
 \n\
-http://www.apache.org/licenses/LICENSE-2.0\n\
+https://www.apache.org/licenses/LICENSE-2.0\n\
 \n\
 Unless required by applicable law or agreed to in writing, software\n\
 distributed under the License is distributed on an AS IS BASIS,\n\
@@ -252,7 +252,7 @@ Licensed under the Apache License, Version 2.0 (the License);\n\
 you may not use this file except in compliance with the License.\n\
 You may obtain a copy of the License at\n\
 \n\
-http://www.apache.org/licenses/LICENSE-2.0\n\
+https://www.apache.org/licenses/LICENSE-2.0\n\
 \n\
 Unless required by applicable law or agreed to in writing, software\n\
 distributed under the License is distributed on an AS IS BASIS,\n\
@@ -269,7 +269,7 @@ Licensed under the Apache License, Version 2.0 (the License);\n\
 you may not use this file except in compliance with the License.\n\
 You may obtain a copy of the License at\n\
 \n\
-http://www.apache.org/licenses/LICENSE-2.0\n\
+https://www.apache.org/licenses/LICENSE-2.0\n\
 \n\
 Unless required by applicable law or agreed to in writing, software\n\
 distributed under the License is distributed on an AS IS BASIS,\n\
@@ -286,7 +286,7 @@ Licensed under the Apache License, Version 2.0 (the License);\n\
 you may not use this file except in compliance with the License.\n\
 You may obtain a copy of the License at\n\
 \n\
-http://www.apache.org/licenses/LICENSE-2.0\n\
+https://www.apache.org/licenses/LICENSE-2.0\n\
 \n\
 Unless required by applicable law or agreed to in writing, software\n\
 distributed under the License is distributed on an AS IS BASIS,\n\
@@ -303,7 +303,7 @@ Licensed under the Apache License, Version 2.0 (the License);\n\
 you may not use this file except in compliance with the License.\n\
 You may obtain a copy of the License at\n\
 \n\
-http://www.apache.org/licenses/LICENSE-2.0\n\
+https://www.apache.org/licenses/LICENSE-2.0\n\
 \n\
 Unless required by applicable law or agreed to in writing, software\n\
 distributed under the License is distributed on an AS IS BASIS,\n\
@@ -325,7 +325,7 @@ License: Apache 2.0\n\
  * you may not use this file except in compliance with the License.\n\
  * You may obtain a copy of the License at\n\
  *\n\
- *       http://www.apache.org/licenses/LICENSE-2.0\n\
+ *       https://www.apache.org/licenses/LICENSE-2.0\n\
  *\n\
  * Unless required by applicable law or agreed to in writing, software\n\
  * distributed under the License is distributed on an "AS IS" BASIS,\n\
@@ -342,7 +342,7 @@ Licensed under the Apache License, Version 2.0 (the "License");\n\
 you may not use this file except in compliance with the License.\n\
 You may obtain a copy of the License at\n\
 \n\
-http://www.apache.org/licenses/LICENSE-2.0\n\
+https://www.apache.org/licenses/LICENSE-2.0\n\
 \n\
 Unless required by applicable law or agreed to in writing, software\n\
 distributed under the License is distributed on an "AS IS" BASIS,\n\
@@ -386,7 +386,7 @@ objenesis-1.2-sources.jar/org/objenesis/instantiator/jrockit/JRockit131Instantia
  * you may not use this file except in compliance with the License.\n\
  * You may obtain a copy of the License at\n\
  * \n\
- * http://www.apache.org/licenses/LICENSE-2.0\n\
+ * https://www.apache.org/licenses/LICENSE-2.0\n\
  * \n\
  * Unless required by applicable law or agreed to in writing, software\n\
  * distributed under the License is distributed on an "AS IS" BASIS,\n\
@@ -426,7 +426,7 @@ Copyright (c) 1997-2005 The Apache Software Foundation. All rights reserved.\n\
 Your use of the Commons IO code is subject to the terms and conditions of the Apache Software License 2.0. A copy of the license is contained in the file \n\
 LICENSE.txt\n\
  and is also available at \n\
-http://www.apache.org/licenses/LICENSE-2.0.html\n\
+https://www.apache.org/licenses/LICENSE-2.0.html\n\
 .\n\
 The Apache attribution \n\
 NOTICE.txt\n\
@@ -563,7 +563,7 @@ The Content includes items that have been sourced from third parties, as set out
 Apache License \n\
 \n\
 Version 2.0, January 2004 \n\
-http://www.apache.org/licenses/ \n\
+https://www.apache.org/licenses/ \n\
 \n\
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION \n\
 \n\

--- a/org.springsource.ide.eclipse.gradle.feature/open_source_licenses.txt
+++ b/org.springsource.ide.eclipse.gradle.feature/open_source_licenses.txt
@@ -173,7 +173,7 @@ The Apache Software Foundation (http://www.apache.org/).
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-* http://www.apache.org/licenses/LICENSE-2.0
+* https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -190,7 +190,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -207,7 +207,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -224,7 +224,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -241,7 +241,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -258,7 +258,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -275,7 +275,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,
@@ -297,7 +297,7 @@ License: Apache 2.0
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -314,7 +314,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -358,7 +358,7 @@ objenesis-1.2-sources.jar\org\objenesis\instantiator\jrockit\JRockit131Instantia
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -398,7 +398,7 @@ Copyright (c) 1997-2005 The Apache Software Foundation. All rights reserved.
 Your use of the Commons IO code is subject to the terms and conditions of the Apache Software License 2.0. A copy of the license is contained in the file 
 LICENSE.txt
  and is also available at 
-http://www.apache.org/licenses/LICENSE-2.0.html
+https://www.apache.org/licenses/LICENSE-2.0.html
 .
 The Apache attribution 
 NOTICE.txt
@@ -535,7 +535,7 @@ The Content includes items that have been sourced from third parties, as set out
 Apache License 
 
 Version 2.0, January 2004 
-http://www.apache.org/licenses/ 
+https://www.apache.org/licenses/ 
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 3 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 30 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.html with 3 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).