### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Installation instructions:
 
 The easiest way to install is from the STS Dashboard "Extensions" page.
 
-  1. First download and install a [recent release of STS](http://www.springsource.org/springsource-tool-suite-download) 
+  1. First download and install a [recent release of STS](https://www.springsource.org/springsource-tool-suite-download) 
      or Groovy and Grails Toolsuite (GGTS) version 3.0.0 or later.
   2. Open the Dashboard and select the 'Extensions' Tab.
   3. Search for "Gradle" or "Groovy" depending on what you are installing, select it and click "Install".
@@ -48,9 +48,9 @@ The easiest way to install is from the STS Dashboard "Extensions" page.
 Alternatively you can install from update sites. The following update
 sites are available:
 
-  * http://dist.springsource.com/snapshot/TOOLS/gradle/nightly (latest development snapshot)
-  * http://dist.springsource.com/milestone/TOOLS/gradle (latest milestone build)
-  * http://dist.springsource.com/release/TOOLS/gradle (latest release)
+  * https://dist.springsource.com/snapshot/TOOLS/gradle/nightly (latest development snapshot)
+  * https://dist.springsource.com/milestone/TOOLS/gradle (latest milestone build)
+  * https://dist.springsource.com/release/TOOLS/gradle (latest release)
   
 Pasting the above URLs into a web browser will not work. You need
 to follow the instructions given below to use an Eclipse update site.
@@ -74,7 +74,7 @@ Use Update Site Archive for STS from <https://spring.io/tools/sts/all>
 
 ## Questions and bug reports:
 
-If you have a question that Google can't answer, the best way is to go to the [STS forum](http://forum.springsource.org/forumdisplay.php?32-SpringSource-Tool-Suite).
+If you have a question that Google can't answer, the best way is to go to the [STS forum](https://forum.spring.io/forumdisplay.php?32-SpringSource-Tool-Suite).
 
 There you can also ask questions and search for other people with related or similar problems (and solutions). New versions of the Gradle Eclipse Integration (and other tooling that is brought to you by SpringSource) are announced there as well.
 
@@ -82,7 +82,7 @@ With regards to bug reports, please go to the [STS issue tracker](https://issuet
 
 ## Developing Eclipse Integration Gradle
 
-The remainder of this documents expects a familiarity with Eclipse architecture and how plugin development works.  If you are not already familiar with Eclipse development, then you may want to read some tutorials about the Eclipse plugin architecture and how to develop with it.  A good start is here: <http://www.ibm.com/developerworks/library/os-eclipse-plugindev1/>.
+The remainder of this documents expects a familiarity with Eclipse architecture and how plugin development works.  If you are not already familiar with Eclipse development, then you may want to read some tutorials about the Eclipse plugin architecture and how to develop with it.  A good start is here: <https://www.ibm.com/developerworks/library/os-eclipse-plugindev1/>.
 
 ### Setting up the Development Environment and Target Platform  
 
@@ -95,12 +95,12 @@ First we will start by setting up a suitable instance of Eclipse. This instance 
 
 Steps:
 
- 1. download and install Eclipse for Java EE Developers from [eclipse.org](http://www.eclipse.org/downloads/).
+ 1. download and install Eclipse for Java EE Developers from [eclipse.org](https://www.eclipse.org/downloads/).
  2. install egit support (e.g. from the Eclipse Market Place). This step is optional, you can also use git commandline tools.
- 4. install Groovy Eclipse from this update site: `http://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2/`
+ 4. install Groovy Eclipse from this update site: `https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2/`
     - install everything on the update site except 'm2e Configurator ...'
     - make sure you *do* install 'Groovy Eclipse Test Feature' if you want to be able to compile and run the Gradle IDE regressions tests.
- 5. install Eclipse Integration Gradle tooling from this update site: `http://dist.springsource.com/snapshot/TOOLS/gradle/nightly`
+ 5. install Eclipse Integration Gradle tooling from this update site: `https://dist.springsource.com/snapshot/TOOLS/gradle/nightly`
  
 ### Getting the source code
 
@@ -167,7 +167,7 @@ Notes:
 
 ## Building Gradle IDE
 
-The Gradle IDE project uses [Maven](http://maven.apache.org/) [Tycho](http://eclipse.org/tycho) to do continuous integration builds and to produce p2 repos and update sites. To build the project yourself, you can execute:
+The Gradle IDE project uses [Maven](https://maven.apache.org/) [Tycho](https://eclipse.org/tycho) to do continuous integration builds and to produce p2 repos and update sites. To build the project yourself, you can execute:
 
     mvn -Pe42 -Dmaven.test.skip=true clean install 
     
@@ -187,10 +187,10 @@ unacceptable behavior to spring-code-of-conduct@pivotal.io.
 ### Get Involved
 Here are some ways for you to get involved in the community:
 
-  * Get involved with the Spring community on the Spring Community Forums.  Please help out on the [forum](http://forum.springsource.org/forumdisplay.php?32-SpringSource-Tool-Suite) by responding to questions and joining the debate.
+  * Get involved with the Spring community on the Spring Community Forums.  Please help out on the [forum](https://forum.spring.io/forumdisplay.php?32-SpringSource-Tool-Suite) by responding to questions and joining the debate.
   * Create [JIRA](https://issuetracker.springsource.com/browse/STS) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-  * Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-  * Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
+  * Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+  * Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 ### Contributor License Agreement
 Before we accept a patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_eclipsecla_committer_signup). Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. Active contributors might be asked to join the core team, and given the ability to merge pull requests.

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd">
 <html><head>
 
 
@@ -12,8 +12,8 @@
   <link rel="stylesheet" href="css/stylesheet.css" type="text/css">
 
   
-  <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type"><title>STS Gradle Support -- FAQ</title></head><body><a href="http://springsource.com/developer/sts"><img style="border: 0px solid ; height: 60px; width: 60px;" alt="logo" src="img/sts60x60.png" align="left"></a>
-<a href="http://www.springsource.com/"><img style="border: 0px solid ; width: 240px; height: 50px;" alt="logo" src="img/spring09_logo.png" align="right"></a><br>
+  <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type"><title>STS Gradle Support -- FAQ</title></head><body><a href="https://springsource.com/developer/sts"><img style="border: 0px solid ; height: 60px; width: 60px;" alt="logo" src="img/sts60x60.png" align="left"></a>
+<a href="https://www.springsource.com/"><img style="border: 0px solid ; width: 240px; height: 50px;" alt="logo" src="img/spring09_logo.png" align="right"></a><br>
 
 
 <br>
@@ -24,7 +24,7 @@
 
 <h1>STS Gradle Support -- 2.9.0 -- FAQ</h1>
 <p class="note">Note: The latest version of this file can always be
-found <a href="http://static.springsource.org/sts/docs/latest/reference/html/gradle/">here</a></p>
+found <a href="https://docs.spring.io/sts/docs/latest/reference/html/gradle/">here</a></p>
 
 
 
@@ -128,7 +128,7 @@ snapshot is required for STS 2.9.0.M2 gradle editor support).
 If a compatible version of Groovy Eclipse is installed, STS-Gradle will provide 
 an option in its Gradle menu to 'Enable DSLD Support'. This will
 add some customizations to your project to enable Groovy Eclipse on your project
-and contribute a <a href="http://docs.codehaus.org/display/GROOVY/DSL+Descriptors+for+Groovy-Eclipse">DSL Descriptor</a>. 
+and contribute a <a href="https://docs.codehaus.org/display/GROOVY/DSL+Descriptors+for+Groovy-Eclipse">DSL Descriptor</a>. 
 This DSL Descriptor is currently quite limited and a work in progress. However you will already 
 get some useful code-assist and JavaDoc hovers if it is turned on.
 <p>
@@ -143,10 +143,10 @@ the STS dashboard, or the most recent dev build via this update site
 3.7):<span style="font-family: monospace;"><br>
 </span><tt><span class="external-link"> </span><br>
 </tt>
-<div style="margin-left: 40px;"><tt><span class="external-link">http://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e3.7/</span></tt></div>
+<div style="margin-left: 40px;"><tt><span class="external-link">https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e3.7/</span></tt></div>
 
 
-<p>The <a href="http://groovy.codehaus.org/Eclipse+Plugin">Groovy-Eclipse
+<p>The <a href="https://groovy.codehaus.org/Eclipse+Plugin">Groovy-Eclipse
 project homepage</a> provides the comprehensive list of available
 update sites.
 </p>
@@ -320,12 +320,12 @@ questions also for more of an explanation why we do this.<br>
 <h3><a name="a17"></a>Where can I ask more questions?</h3>
 
 
-If you have questions about the STS Gradle tooling, the <a href="http://forum.springsource.org/forumdisplay.php?f=32">STS Forum</a>
+If you have questions about the STS Gradle tooling, the <a href="https://forum.spring.io/forumdisplay.php?f=32">STS Forum</a>
 is a good place
 to ask.
 <br>
 
-If you have questions about Gradle, please consult the <a href="http://gradle.org/help-and-support">Gradle Help & Support
+If you have questions about Gradle, please consult the <a href="https://gradle.org/help-and-support">Gradle Help & Support
 page</a>.
 
 <h3><a name="a18"></a>Where can I report a bug?</h3>
@@ -335,7 +335,7 @@ If your bug is related to the STS Gradle tooling use the <a href="https://issuet
 tracker</a>.<br>
 
 If your bug is related to Gradle itself, please consult the <a
-href="http://gradle.org/help-and-support">Gradle Help & Support
+href="https://gradle.org/help-and-support">Gradle Help & Support
 page</a>.<br>
 
 If you don't know for sure which one it is, make your best guess.<br>
@@ -363,8 +363,8 @@ prompted, and what it means to accept or reject the UAA agreement.<br>
 <br>
 
 
-For details please see the <a href="http://www.springsource.org/uaa/faq">Spring User Agent Analysis
-FAQ</a> and the <a href="http://www.springsource.org/uaa/terms_of_use">UAA
+For details please see the <a href="https://www.springsource.org/uaa/faq">Spring User Agent Analysis
+FAQ</a> and the <a href="https://www.springsource.org/uaa/terms_of_use">UAA
 Terms of Use</a>.<br>
 
 
@@ -372,7 +372,7 @@ Terms of Use</a>.<br>
 <br>
 
 
-From the <a href="http://www.springsource.org/uaa/faq">Spring User
+From the <a href="https://www.springsource.org/uaa/faq">Spring User
 Agent Analysis FAQ</a>: "<span style="font-style: italic;">Spring UAA
 helps us gain a better understanding of how people are using Spring
 technologies. Of course your privacy is of paramount importance. For
@@ -411,7 +411,7 @@ default. You can paste in the following URL:<br>
 <br>
 
 
-<div style="margin-left: 40px;"><a href="http://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-3-bin.zip">http://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-3-bin.zip</a>
+<div style="margin-left: 40px;"><a href="https://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-3-bin.zip">https://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-3-bin.zip</a>
 <br>
 </div>
 
@@ -436,7 +436,7 @@ wrapper properties file"</h3>
 
 
 The Gradle tooling API 1.0-milestone-3 raises this error when you are using a Gradle
-Wrapper generated with an older version of Gradle. For a workaround see the question above. Also see issue <a href="http://issues.gradle.org/browse/GRADLE-1527">GRADLE-1527</a>.<br>
+Wrapper generated with an older version of Gradle. For a workaround see the question above. Also see issue <a href="https://issues.gradle.org/browse/GRADLE-1527">GRADLE-1527</a>.<br>
 
 
 <h3><a name="a22"></a>How can I disable the STS Dashboard?</h3>

--- a/docs/gradle-sts-tutorial.html
+++ b/docs/gradle-sts-tutorial.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd">
 <html><head>
 
 
@@ -8,7 +8,7 @@
 
   
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type"><title>Gradle STS Support -- Tutorial</title></head><body>
-<a href="http://springsource.com/developer/sts"><img style="border: 0px solid ; height: 60px; width: 60px;" alt="logo" src="img/sts60x60.png" align="left"></a><a href="http://www.springsource.com/"><img style="border: 0px solid ; width: 240px; height: 50px;" alt="logo" src="img/spring09_logo.png" align="right"></a><br>
+<a href="https://springsource.com/developer/sts"><img style="border: 0px solid ; height: 60px; width: 60px;" alt="logo" src="img/sts60x60.png" align="left"></a><a href="https://www.springsource.com/"><img style="border: 0px solid ; width: 240px; height: 50px;" alt="logo" src="img/spring09_logo.png" align="right"></a><br>
 
 <br>
 
@@ -18,20 +18,20 @@
 <h1>Gradle STS Support -- 2.9.0 -- Tutorial</h1>
 
 <p class="note">Note: The latest version of this file can always be
-found <a href="http://static.springsource.org/sts/docs/latest/reference/html/gradle/">here</a></p>
+found <a href="https://docs.spring.io/sts/docs/latest/reference/html/gradle/">here</a></p>
 
 <p>This tutorial will take you through the process of using the STS-Gradle
 tooling to import a Gradle multi-project into STS and execute some
 Gradle tasks on the imported project(s). This tutorial does not cover
 how to install the Gradle tooling into STS.</p>
 
-<p>We will use <a href="http://static.springsource.org/spring-security/site/">spring-security
+<p>We will use <a href="https://docs.spring.io/spring-security/site/">spring-security
 project</a> as a running example throughout this tutorial.</p>
 
-<p class="note">Note: There is also an <a href="http://static.springsource.org/sts/docs/2.7.0.M1/reference/html/gradle/gradle-sts-tutorial.html">older
+<p class="note">Note: There is also an <a href="https://docs.spring.io/sts/docs/2.7.0.M1/reference/html/gradle/gradle-sts-tutorial.html">older
 version of this tutorial</a> based on the spring-integration project.</p>
 
-<p>If you want to follow along, the first step is to checkout the <a href="http://static.springsource.org/spring-security/site/source.html">source
+<p>If you want to follow along, the first step is to checkout the <a href="https://docs.spring.io/spring-security/site/source.html">source
 code</a> from git:</p>
 
 <pre style="margin-left: 40px;">git clone git://git.springsource.org/spring-security/spring-security.git</pre>
@@ -716,7 +716,7 @@ repors at <br>
 issue
 tracker</a><br>
       </li>
-      <li>The <a href="http://forum.springsource.org/forumdisplay.php?f=32">STS forum</a>
+      <li>The <a href="https://forum.spring.io/forumdisplay.php?f=32">STS forum</a>
         <br>
       </li>
     </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,13 +1,13 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd">
 <html><head>
   <link rel="stylesheet" href="css/stylesheet.css" type="text/css">
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type"><title>Gradle STS Support -- Index</title></head>
-  <body><a href="http://springsource.com/developer/sts"><img style="border: 0px solid ; height: 60px; width: 60px;" alt="logo" src="img/sts60x60.png" align="left" hspace="0" vspace="0"></a>
-<a href="http://www.springsource.com/"><img style="border: 0px solid ; width: 240px; height: 50px;" alt="logo" src="img/spring09_logo.png" align="right" hspace="0" vspace="0"></a><br><br><br>
+  <body><a href="https://springsource.com/developer/sts"><img style="border: 0px solid ; height: 60px; width: 60px;" alt="logo" src="img/sts60x60.png" align="left" hspace="0" vspace="0"></a>
+<a href="https://www.springsource.com/"><img style="border: 0px solid ; width: 240px; height: 50px;" alt="logo" src="img/spring09_logo.png" align="right" hspace="0" vspace="0"></a><br><br><br>
 
 <h1>Gradle STS Support -- 2.9.0 -- Index</h1>
 <p class="note">Note: The latest version of this file can always be
-found <a href="http://static.springsource.org/sts/docs/latest/reference/html/gradle/">here</a>.</p>
+found <a href="https://docs.spring.io/sts/docs/latest/reference/html/gradle/">here</a>.</p>
 
 <p>Since 2.7.M1 STS includes a, basic set of features to support
 working with Gradle projects inside of STS. Presently we provide three main chunks of functionality:</p>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd">
 <html><head>
 <link rel="stylesheet" href="css/stylesheet.css" type="text/css">
 <title>Gradle STS Tooling Docs</title>
 </head><body>
 <h1>Gradle STS Support -- 3.0.0 (M2) -- Installation</h1>
 
-<p><small>Note: The latest version of this file can always be found <a href="http://static.springsource.org/sts/docs/latest/reference/html/gradle/" title="Latest Gradle Docs">here</a>.</small></p>
+<p><small>Note: The latest version of this file can always be found <a href="https://docs.spring.io/sts/docs/latest/reference/html/gradle/" title="Latest Gradle Docs">here</a>.</small></p>
 
 <p>You can install the Gradle STS support in one of two ways. The easiest
 way to install is from the STS Dashboard extensions page. Simply search
@@ -46,9 +46,9 @@ required (STS 3.0.0.M2) requires Groovy Eclipse 2.7.0. The Gradle tooling should
 sites are available:</p>
 
 <ul>
-<li>http://dist.springsource.com/snapshot/TOOLS/nightly/gradle (latest development snapshot)</li>
-<li>http://dist.springsource.com/milestone/TOOLS/gradle (latest milestone build.)</li>
-<li>http://dist.springsource.com/release/TOOLS/gradle (latest release)</li>
+<li>https://dist.springsource.com/snapshot/TOOLS/nightly/gradle (latest development snapshot)</li>
+<li>https://dist.springsource.com/milestone/TOOLS/gradle (latest milestone build.)</li>
+<li>https://dist.springsource.com/release/TOOLS/gradle (latest release)</li>
 </ul>
 
 <p><strong>Note:</strong> pasting the above URLs into a web browser will not work. You need
@@ -66,15 +66,15 @@ sufficient.</p>
 <ul>
 <li>For eclipse 3.7:
 <ul>
-<li>STS Release: http://dist.springsource.com/release/TOOLS/update/e3.7/ (this site will only contain a compatible version after 3.0.0 release!)</li>
-<li>Milestone: http://dist.springsource.com/milestone/TOOLS/update/e3.7/</li>
-<li>Nightly: http://dist.springsource.com/snapshot/TOOLS/nightly/e3.7/</li>
+<li>STS Release: https://dist.springsource.com/release/TOOLS/update/e3.7/ (this site will only contain a compatible version after 3.0.0 release!)</li>
+<li>Milestone: https://dist.springsource.com/milestone/TOOLS/update/e3.7/</li>
+<li>Nightly: https://dist.springsource.com/snapshot/TOOLS/nightly/e3.7/</li>
 </ul></li>
 <li>For eclipse 4.2:
 <ul>
-<li>STS Release: http://dist.springsource.com/release/TOOLS/update/e4.2/ (this site will only contain a compatible version after 3.0.0 release!)</li>
-<li>Milestone: http://dist.springsource.com/milestone/TOOLS/update/e4.2/</li>
-<li>Nightly: http://dist.springsource.com/snapshot/TOOLS/nightly/e4.1/</li>
+<li>STS Release: https://dist.springsource.com/release/TOOLS/update/e4.2/ (this site will only contain a compatible version after 3.0.0 release!)</li>
+<li>Milestone: https://dist.springsource.com/milestone/TOOLS/update/e4.2/</li>
+<li>Nightly: https://dist.springsource.com/snapshot/TOOLS/nightly/e4.1/</li>
 </ul></li>
 </ul>
 
@@ -96,5 +96,5 @@ sufficient.</p>
 
 <h3>Installing Groovy Eclipse from Update Site</h3>
 
-<p>To install Groovy Eclipse from update site see <a href="http://groovy.codehaus.org/Eclipse+Plugin" title="Groovy Eclipse">here</a>.</p>
+<p>To install Groovy Eclipse from update site see <a href="https://groovy.codehaus.org/Eclipse+Plugin" title="Groovy Eclipse">here</a>.</p>
 </body></html>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,9 +38,9 @@ The easiest way to install is from the STS Dashboard "Extensions" page.
 Alternatively you can install from update sites. The following update
 sites are available:
 
-  * http://dist.springsource.com/snapshot/TOOLS/nightly/gradle (latest development snapshot)
-  * http://dist.springsource.com/milestone/TOOLS/gradle (latest milestone build.)
-  * http://dist.springsource.com/release/TOOLS/gradle (latest release)
+  * https://dist.springsource.com/snapshot/TOOLS/nightly/gradle (latest development snapshot)
+  * https://dist.springsource.com/milestone/TOOLS/gradle (latest milestone build.)
+  * https://dist.springsource.com/release/TOOLS/gradle (latest release)
 
 **Note:** pasting the above URLs into a web browser will not work. You need
 to follow the instructions given below to use an Eclipse update site.
@@ -55,13 +55,13 @@ sufficient.
 **If you are installing in a plain Eclipse**, you will also need to add an STS update site to satisfy some dependencies.
 
   * For eclipse 3.7:
-     * STS Release: http://dist.springsource.com/release/TOOLS/update/e3.7/ (this site will only contain a compatible version after 3.0.0 release!)
-     * Milestone: http://dist.springsource.com/milestone/TOOLS/update/e3.7/
-     * Nightly: http://dist.springsource.com/snapshot/TOOLS/nightly/e3.7/
+     * STS Release: https://dist.springsource.com/release/TOOLS/update/e3.7/ (this site will only contain a compatible version after 3.0.0 release!)
+     * Milestone: https://dist.springsource.com/milestone/TOOLS/update/e3.7/
+     * Nightly: https://dist.springsource.com/snapshot/TOOLS/nightly/e3.7/
   * For eclipse 4.2:
-     * STS Release: http://dist.springsource.com/release/TOOLS/update/e4.2/ (this site will only contain a compatible version after 3.0.0 release!)
-     * Milestone: http://dist.springsource.com/milestone/TOOLS/update/e4.2/
-     * Nightly: http://dist.springsource.com/snapshot/TOOLS/nightly/e4.2/
+     * STS Release: https://dist.springsource.com/release/TOOLS/update/e4.2/ (this site will only contain a compatible version after 3.0.0 release!)
+     * Milestone: https://dist.springsource.com/milestone/TOOLS/update/e4.2/
+     * Nightly: https://dist.springsource.com/snapshot/TOOLS/nightly/e4.2/
      
 #### Detailed instructions: 
 
@@ -81,5 +81,5 @@ Steps 2..4 can be skipped if you are installing into STS.
 
 To install Groovy Eclipse from update site see [here][greclipse].
 
-   [latest]: http://static.springsource.org/sts/docs/latest/reference/html/gradle/  "Latest Gradle Docs"
-   [greclipse]: http://groovy.codehaus.org/Eclipse+Plugin "Groovy Eclipse"
+   [latest]: https://docs.spring.io/sts/docs/latest/reference/html/gradle/  "Latest Gradle Docs"
+   [greclipse]: https://groovy.codehaus.org/Eclipse+Plugin "Groovy Eclipse"

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -165,7 +165,7 @@ Apache Commons Collections
 Copyright 2001-2008 The Apache Software Foundation
 
 This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 * Copyright 1999,2004 The Apache Software Foundation.
 *
@@ -380,17 +380,17 @@ About This Content
 June 8, 2007
 License
 The Eclipse Foundation makes available all content in this plug-in ("Content"). Unless otherwise indicated below, the Content is provided to you under the terms and conditions of the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is available at 
-http://www.eclipse.org/legal/epl-v10.html
+https://www.eclipse.org/legal/epl-v10.html
 . For purposes of the EPL, "Program" will mean the Content.
 If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by another party ("Redistributor") and different terms and conditions may apply to your use of any object code in the Content. Check the Redistributor's license that was provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise indicated below, the terms and conditions of the EPL still apply to any source code in the Content and such source code may be obtained at 
-http://www.eclipse.org
+https://www.eclipse.org
 .
 Third Party Content
 The Content includes items that have been sourced from third parties as set out below. If you did not receive this Content directly from the Eclipse Foundation, the following is provided for informational purposes only, and you should look to the Redistributors license for terms and conditions of use.
 Apache Commons IO 2.2.0
 The plug-in includes Commons IO 2.2.0 ("Commons IO") developed by the Apache Software Foundation. Therefore:
 This product includes software developed by the Apache Software Foundation (
-http://www.apache.org/
+https://www.apache.org/
 ).
 The Commons IO binary code is included with no modifications except postprocessing (pack200 conditioning and signing). The corresponding Commons IO source code is located in src.zip.
 Commons IO is:
@@ -404,7 +404,7 @@ The Apache attribution
 NOTICE.txt
  file is included with the Content in accordance with 4d of the Apache License, Version 2.0.
 Examples and documentation as well as updated source code for Commons IO is available at 
-http://commons.apache.org/io/
+https://commons.apache.org/io/
 .
 
 
@@ -415,10 +415,10 @@ About This Content
 June 5, 2006
 License
 The Eclipse Foundation makes available all content in this plug-in ("Content"). Unless otherwise indicated below, the Content is provided to you under the terms and conditions of the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is available at 
-http://www.eclipse.org/legal/epl-v10.html
+https://www.eclipse.org/legal/epl-v10.html
 . For purposes of the EPL, "Program" will mean the Content.
 If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by another party ("Redistributor") and different terms and conditions may apply to your use of any object code in the Content. Check the Redistributor's license that was provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise indicated below, the terms and conditions of the EPL still apply to any source code in the Content and such source code may be obtained at 
-http://www.eclipse.org
+https://www.eclipse.org
 .
 
 
@@ -945,7 +945,7 @@ available (as would be noted above), you may obtain a copy of
 the source code corresponding to the binaries for such open
 source components and modifications thereto, if any, (the
 "Source Files"), by downloading the Source Files from Pivotal's website at
-http://network.pivotal.io/open-source, or by sending a request, 
+https://network.pivotal.io/open-source, or by sending a request, 
 with your name and address to: Pivotal Software, Inc., 875 Howard Street, 5th
 floor, San Francisco, CA 94103, Attention: General Counsel. All such requests
 should clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. 

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject-m6/boink/Main.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject-m6/boink/Main.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject-m6/boink2/Spain.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject-m6/boink2/Spain.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject/boink/Main.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject/boink/Main.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject/boink2/Spain.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject/boink2/Spain.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts-2407/projectA/projectB/projectC/src/main/java/test/Test1.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts-2407/projectA/projectB/projectC/src/main/java/test/Test1.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts-2407/projectA/projectB/projectD/src/test/java/test/Test1Test.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts-2407/projectA/projectB/projectD/src/test/java/test/Test1Test.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1842/greeteds/world/src/main/java/World.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1842/greeteds/world/src/main/java/World.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1842/hello/src/main/java/Hello.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1842/hello/src/main/java/Hello.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1842/src/main/java/Greetings.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1842/src/main/java/Greetings.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1950/A/src/main/java/testa/TestA.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1950/A/src/main/java/testa/TestA.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1950/B/src/test/java/testb/TestB.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1950/B/src/test/java/testb/TestB.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1950/C/src/main/java/testc/TestC.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts1950/C/src/main/java/testc/TestC.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts2185/A/src/main/webapp/index.jsp
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts2185/A/src/main/webapp/index.jsp
@@ -1,7 +1,7 @@
 <%@page import="java.util.Date"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts2185/Junk/src/junk/Junk.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts2185/Junk/src/junk/Junk.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * GoPivotal, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts3953/my-lib/src/main/java/my/cool/lib/CoolLib.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts3953/my-lib/src/main/java/my/cool/lib/CoolLib.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts3953/product/src/main/java/my/cool/app/Runner.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts3953/product/src/main/java/my/cool/app/Runner.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts_2205/src/main/java/testb/TestB.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts_2205/src/main/java/testb/TestB.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts_2205/src/main/java/testb2/TestB2.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/sts_2205/src/main/java/testb2/TestB2.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/modelmanager/test/DefaultModelBuilderTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/modelmanager/test/DefaultModelBuilderTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/modelmanager/test/GradleModelManagerTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/modelmanager/test/GradleModelManagerTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/modelmanager/test/ModelPromise.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/modelmanager/test/ModelPromise.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/AllGradleCoreTests.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/AllGradleCoreTests.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/ArgumentsParserTests.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/ArgumentsParserTests.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/ArrayEncoderTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/ArrayEncoderTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/ClasspathContainerTests.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/ClasspathContainerTests.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/DistributionValidatorTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/DistributionValidatorTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleImportTests.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleImportTests.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -154,7 +154,7 @@ public class GradleImportTests extends GradleTest {
 		//			}
 		//		
 // Use wrapper version
-//		URI distro = new URI("http://services.gradle.org/distributions/gradle-1.3-bin.zip");
+//		URI distro = new URI("https://services.gradle.org/distributions/gradle-1.3-bin.zip");
 //		GradleCore.getInstance().getPreferences().setDistribution(distro);
 
 		final GradleImportOperation importOp = importGitProjectOperation(new GitProject("spring-framework", 

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleMenuEnablementTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleMenuEnablementTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleProjectTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleProjectTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleRefreshPreferencesTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleRefreshPreferencesTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleSampleProjectTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleSampleProjectTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleTaskRunTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleTaskRunTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -236,7 +236,7 @@ public class GradleTaskRunTest extends GradleTest {
 	 */
 	public void testDependencyByAPI() throws Exception {
 		//TODO: this test is failing, but report submitted:
-		// http://issues.gradle.org/browse/GRADLE-1555
+		// https://issues.gradle.org/browse/GRADLE-1555
 		String name = "dependencyByAPI";
 		IJavaProject jproject = simpleProject(name, 
 				"4.times { counter ->\n" + 
@@ -458,7 +458,7 @@ public class GradleTaskRunTest extends GradleTest {
 	}
 
 	//TODO: Default tasks... (Example 5.15)
-	// Waiting for http://issues.gradle.org/browse/GRADLE-1560
+	// Waiting for https://issues.gradle.org/browse/GRADLE-1560
 
 	/**
 	 * Example 5.16: using task DAG

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/GradleTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -335,7 +335,7 @@ public abstract class GradleTest extends TestCase {
 	public static File extractJavaSample(final String projectName)
 			throws IOException, Exception, URISyntaxException {
 		final File targetLocation = new File(TestUtils.createTempDirectory(), projectName);
-		DownloadManager.getDefault().doWithDownload(new URI("http://services.gradle.org/distributions/gradle-2.1-all.zip"), new DownloadRequestor() {
+		DownloadManager.getDefault().doWithDownload(new URI("https://services.gradle.org/distributions/gradle-2.1-all.zip"), new DownloadRequestor() {
 			public void exec(File downloadedFile) throws Exception {
 				ZipFileUtil.unzip(downloadedFile.toURI().toURL(), targetLocation, "gradle-2.1/samples/java/"+projectName);
 			}
@@ -566,7 +566,7 @@ public abstract class GradleTest extends TestCase {
 			//while the last test is still running.
 			//Mostly this doesn't cause problems, unless the test is doing something that is susceptible to
 			//'interrupts', like the file copying methods in apache FileUtils.
-			//See also here: http://stackoverflow.com/questions/1161297/why-are-we-getting-closedbyinterruptexception-from-filechannel-map-in-java-1-6
+			//See also here: https://stackoverflow.com/questions/1161297/why-are-we-getting-closedbyinterruptexception-from-filechannel-map-in-java-1-6
 			try {
 				copyFolder = new File(parentFolder, orgFolder.getName());
 				FileUtils.copyDirectory(orgFolder, copyFolder);

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/JarRemappingTests.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/JarRemappingTests.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/MockNewProjectWizardUI.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/MockNewProjectWizardUI.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/NewProjectWizardValidatorTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/NewProjectWizardValidatorTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/Predicate.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/Predicate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *    Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/TopoSortTest.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/TopoSortTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/ACondition.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/ACondition.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/AddedResourceListener.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/AddedResourceListener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/ExternalCommand.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/ExternalCommand.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/ExternalProcess.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/ExternalProcess.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/GitProject.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/GitProject.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/InterruptEater.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/InterruptEater.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/JUnitLaunchConfigUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/JUnitLaunchConfigUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/JavaUtils.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/JavaUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/JavaXXRuntime.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/JavaXXRuntime.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/KillGradleDaemons.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/KillGradleDaemons.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/LoggingProgressMonitor.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/LoggingProgressMonitor.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/ManagedTestSuite.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/ManagedTestSuite.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -238,7 +238,7 @@ public class ManagedTestSuite extends TestSuite {
 //			System.err.println(info);
 //			System.err.print("Proxy : " + WebUtil.getProxy("google.com", IProxyData.HTTP_PROXY_TYPE) + " (Platform)");
 //			try {
-//				System.err.print(" / " + ProxySelector.getDefault().select(new URI("http://google.com")) + " (Java)");
+//				System.err.print(" / " + ProxySelector.getDefault().select(new URI("https://google.com")) + " (Java)");
 //			}
 //			catch (URISyntaxException e) {
 //				// ignore

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/MavenCommand.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/MavenCommand.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/RefreshAllActionCoreTests.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/RefreshAllActionCoreTests.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/TestProjectConfigurators.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/TestProjectConfigurators.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/TestUtils.java
+++ b/org.springsource.ide.eclipse.gradle.core.test/src/org/springsource/ide/eclipse/gradle/core/test/util/TestUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/samples/flat-java-multiproject/my-lib/src/main/java/my/cool/lib/CoolLib.java
+++ b/org.springsource.ide.eclipse.gradle.core/samples/flat-java-multiproject/my-lib/src/main/java/my/cool/lib/CoolLib.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/samples/flat-java-multiproject/product/src/main/java/my/cool/app/Runner.java
+++ b/org.springsource.ide.eclipse.gradle.core/samples/flat-java-multiproject/product/src/main/java/my/cool/app/Runner.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ClassPath.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ClassPath.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/Debug.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/Debug.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/DefaultProjectMapper.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/DefaultProjectMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ExistingWorkspaceProjectMapper.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ExistingWorkspaceProjectMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleCore.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleCore.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleNature.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleNature.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleProject.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleProject.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleProjectManager.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleProjectManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleSaveParticipant.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/GradleSaveParticipant.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/IProjectMapper.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/IProjectMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/InconsistenProjectHierarchyException.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/InconsistenProjectHierarchyException.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectConfigurationManager.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectConfigurationManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectConfigurationRequest.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectConfigurationRequest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectHierarchyVisitor.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectHierarchyVisitor.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectMapperFactory.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectMapperFactory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectOpenCloseListener.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectOpenCloseListener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectOpenCloseListenerManager.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/ProjectOpenCloseListenerManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *    Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/SystemPropertyCleaner.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/SystemPropertyCleaner.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/TaskUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/TaskUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -62,7 +62,7 @@ public class TaskUtil {
 			Job.getJobManager().beginRule(JobUtil.LIGHT_RULE, new SubProgressMonitor(mon, 5));
 			//cumulative work: 5%
 			try {
-//				project = project.getRootProject(); //Workaround for bug http://issues.gradle.org/browse/GRADLE-1765
+//				project = project.getRootProject(); //Workaround for bug https://issues.gradle.org/browse/GRADLE-1765
 				// is ok to go via root, since task path strings are 'absolute' anyway.
 				ProjectConnection conn = ToolinApiUtils.getGradleConnector(project, new SubProgressMonitor(mon, 5));
 				//cumulative work: 10%

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/Continuable.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/Continuable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/GradleRefreshPreferences.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/GradleRefreshPreferences.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/IProjectProvider.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/IProjectProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/RefreshAllActionCore.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/RefreshAllActionCore.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/RefreshDependenciesActionCore.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/RefreshDependenciesActionCore.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/ReimportOperation.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/actions/ReimportOperation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/api/IProjectConfigurationRequest.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/api/IProjectConfigurationRequest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/api/IProjectConfigurator.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/api/IProjectConfigurator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/autorefresh/DependencyRefresher.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/autorefresh/DependencyRefresher.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/autorefresh/GradleWorkspaceListener.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/autorefresh/GradleWorkspaceListener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/autorefresh/IDirtyProjectListener.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/autorefresh/IDirtyProjectListener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/ClassPathModel.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/ClassPathModel.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/FastOperationFailedException.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/FastOperationFailedException.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/GradleClassPathContainer.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/GradleClassPathContainer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/GradleClasspathContainerInitializer.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/GradleClasspathContainerInitializer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/GradleDependencyComputer.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/GradleDependencyComputer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -150,7 +150,7 @@ public class GradleDependencyComputer {
 					}
 				} else {
 					//'non jar' entries may happen when project has a dependency on a sourceSet's output folder.
-					//See http://issues.gradle.org/browse/GRADLE-1766
+					//See https://issues.gradle.org/browse/GRADLE-1766
 					boolean isCovered = false;
 					IProject containingProject = WorkspaceUtil.getContainingProject(file);
 					if (containingProject!=null) {

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/JarRemapRefresher.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/JarRemapRefresher.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/MarkerMaker.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/classpathcontainer/MarkerMaker.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradleLaunchConfigurationDelegate.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradleLaunchConfigurationDelegate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradleOutputStreamMonitor.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradleOutputStreamMonitor.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradlePipedInputStream.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradlePipedInputStream.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradleProcess.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradleProcess.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradleStreamsProxy.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/GradleStreamsProxy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/LaunchTerminationListener.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/LaunchTerminationListener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/LaunchUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/launch/LaunchUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/AbstractModelBuilder.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/AbstractModelBuilder.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/BuildResult.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/BuildResult.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/BuildScheduler.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/BuildScheduler.java
@@ -3,7 +3,7 @@
 // * All rights reserved. This program and the accompanying materials
 // * are made available under the terms of the Eclipse Public License v1.0
 // * which accompanies this distribution, and is available at
-// * http://www.eclipse.org/legal/epl-v10.html
+// * https://www.eclipse.org/legal/epl-v10.html
 // *
 // * Contributors:
 // * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/BuildStrategy.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/BuildStrategy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/DefaultModelBuilder.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/DefaultModelBuilder.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/GradleModelManager.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/GradleModelManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/GradleProjectModelManager.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/GradleProjectModelManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/HierarchicalProjectBuildStrategy.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/HierarchicalProjectBuildStrategy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/IGradleModelListener.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/IGradleModelListener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/LockManager.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/LockManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/ModelBuilder.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/ModelBuilder.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/ProjectBuildResult.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/ProjectBuildResult.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/SingleProjectBuildStrategy.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/SingleProjectBuildStrategy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/ToolinApiUtils.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/modelmanager/ToolinApiUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/AbstractGradlePreferences.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/AbstractGradlePreferences.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/AbstractGradleProjectPreferences.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/AbstractGradleProjectPreferences.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GlobalSettings.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GlobalSettings.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradleAPIProperties.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradleAPIProperties.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradleImportPreferences.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradleImportPreferences.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradlePreferences.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradlePreferences.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradleProjectPreferences.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/GradleProjectPreferences.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/IJavaHomePreferences.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/preferences/IJavaHomePreferences.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/samples/GradleDistributionSample.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/samples/GradleDistributionSample.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/samples/LocalSample.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/samples/LocalSample.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/samples/SampleProject.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/samples/SampleProject.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/samples/SampleProjectRegistry.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/samples/SampleProjectRegistry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -75,7 +75,7 @@ public class SampleProjectRegistry {
 	private URI distribution;
 	{
 		try {
-			distribution = new URI("http://services.gradle.org/distributions/gradle-2.1-all.zip");
+			distribution = new URI("https://services.gradle.org/distributions/gradle-2.1-all.zip");
 		} catch (URISyntaxException e) {
 			throw new Error(e);
 		}
@@ -90,7 +90,7 @@ public class SampleProjectRegistry {
 //The sample project below doesn't represent a layout that works well in the STS Eclipse environment							
 //					new GradleDistributionSample(downloadManager, distribution, 
 //							"Java Multiproject", "samples/java/multiproject")
-// The sample project below doesn't work properly. See http://issues.gradle.org/browse/GRADLE-2251
+// The sample project below doesn't work properly. See https://issues.gradle.org/browse/GRADLE-2251
 //					new GradleDistributionSample(downloadManager, distribution, 
 //							"Base- and Sub-project", "samples/java/base")
 			registerLocalSamples();

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ArgumentsCustomizerHelper.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ArgumentsCustomizerHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ArgumentsParser.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ArgumentsParser.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ArrayEncoder.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ArrayEncoder.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Box.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Box.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/BusyStatus.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/BusyStatus.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ConsoleUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ConsoleUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Continuation.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Continuation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Distributions.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Distributions.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -62,14 +62,14 @@ public class Distributions {
 	public static URI milestoneURI(int num) throws URISyntaxException {
 		Assert.isLegal(num>=3 && num<=9);
 		if (num<9) {
-			return new URI("http://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-"+num+"-bin.zip");
+			return new URI("https://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-"+num+"-bin.zip");
 		} else {
-			return new URI("http://services.gradle.org/distributions/gradle-1.0-milestone-"+num+"-bin.zip");
+			return new URI("https://services.gradle.org/distributions/gradle-1.0-milestone-"+num+"-bin.zip");
 		}
 	}
 
 	public static URI releaseURI(int majorVersion, int minorVersion) throws URISyntaxException {
-		return new URI("http://services.gradle.org/distributions/gradle-"+majorVersion+"."+minorVersion+"-bin.zip");
+		return new URI("https://services.gradle.org/distributions/gradle-"+majorVersion+"."+minorVersion+"-bin.zip");
 	}
 	
 }

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/DownloadManager.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/DownloadManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ErrorHandler.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ErrorHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ExceptionUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ExceptionUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Gradle1792BugException.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Gradle1792BugException.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation
@@ -12,7 +12,7 @@ package org.springsource.ide.eclipse.gradle.core.util;
 
 /**
  * Exception that is thrown when we suspect that we have hit the bug
- * http://issues.gradle.org/browse/GRADLE-1792
+ * https://issues.gradle.org/browse/GRADLE-1792
  * 
  * @author Kris De Volder
  */
@@ -22,7 +22,7 @@ public class Gradle1792BugException extends Exception {
 	
 	private static final String EXPLANATION = 
 			"Most likely you are hitting bug\n" +
-			"http://issues.gradle.org/browse/GRADLE-1792\n\n" +
+			"https://issues.gradle.org/browse/GRADLE-1792\n\n" +
 			"To avoid the bug, please make sure that the Gradle Eclipse Plugin " +
 			"is applied to all your projects, or that your are using a version " +
 			"of Gradle M4 or later.";

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleOpearionProgressMonitor.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleOpearionProgressMonitor.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleProjectIndex.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleProjectIndex.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleProjectSorter.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleProjectSorter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleProjectUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleProjectUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleRunnable.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/GradleRunnable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/HttpUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/HttpUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/IllegalClassPathEntryException.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/IllegalClassPathEntryException.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/JavaRuntimeUtils.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/JavaRuntimeUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/JobUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/JobUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Joinable.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/Joinable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/JoinableContinuation.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/JoinableContinuation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/NatureUtils.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/NatureUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/NullJoinable.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/NullJoinable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ObjectUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ObjectUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/OsUtils.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/OsUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ProjectTasksVisibility.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ProjectTasksVisibility.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ResourceFilterFactory.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ResourceFilterFactory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ResourceListEncoder.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ResourceListEncoder.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/RestrictedCapacityStack.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/RestrictedCapacityStack.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/SystemOutAsProgress.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/SystemOutAsProgress.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/TimeUtils.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/TimeUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/TopoSort.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/TopoSort.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/WorkspaceUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/WorkspaceUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ZipFileUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/ZipFileUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/expression/LiveExpression.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/expression/LiveExpression.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/expression/LiveVariable.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/expression/LiveVariable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/expression/ValueListener.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/util/expression/ValueListener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/CompositeValidator.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/CompositeValidator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/DistributionValidator.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/DistributionValidator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/DistributionValidatorContext.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/DistributionValidatorContext.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/JavaHomeValidator.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/JavaHomeValidator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/JavaHomeValidatorContext.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/JavaHomeValidatorContext.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/NewProjectLocationValidator.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/NewProjectLocationValidator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/ProjectNameValidator.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/ProjectNameValidator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/SampleProjectValidator.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/SampleProjectValidator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/ValidationResult.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/ValidationResult.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/Validator.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/validators/Validator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/FlatPrecomputedProjectMapper.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/FlatPrecomputedProjectMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/GradleImportOperation.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/GradleImportOperation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/HierarchicalProjectMapper.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/HierarchicalProjectMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/NewGradleProjectOperation.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/NewGradleProjectOperation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/PrecomputedProjectMapper.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wizards/PrecomputedProjectMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wtp/DeploymentExclusions.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wtp/DeploymentExclusions.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wtp/RegexpListDeploymentExclusions.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wtp/RegexpListDeploymentExclusions.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wtp/WTPUtil.java
+++ b/org.springsource.ide.eclipse.gradle.core/src/org/springsource/ide/eclipse/gradle/core/wtp/WTPUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.feature/feature.properties
+++ b/org.springsource.ide.eclipse.gradle.feature/feature.properties
@@ -193,7 +193,7 @@ Apache Commons Collections\n\
 Copyright 2001-2008 The Apache Software Foundation\n\
 \n\
 This product includes software developed by\n\
-The Apache Software Foundation (http://www.apache.org/).\n\
+The Apache Software Foundation (https://www.apache.org/).\n\
 \n\
 * Copyright 1999,2004 The Apache Software Foundation.\n\
 *\n\
@@ -408,17 +408,17 @@ About This Content\n\
 June 8, 2007\n\
 License\n\
 The Eclipse Foundation makes available all content in this plug-in ("Content"). Unless otherwise indicated below, the Content is provided to you under the terms and conditions of the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is available at \n\
-http://www.eclipse.org/legal/epl-v10.html\n\
+https://www.eclipse.org/legal/epl-v10.html\n\
 . For purposes of the EPL, "Program" will mean the Content.\n\
 If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by another party ("Redistributor") and different terms and conditions may apply to your use of any object code in the Content. Check the Redistributor's license that was provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise indicated below, the terms and conditions of the EPL still apply to any source code in the Content and such source code may be obtained at \n\
-http://www.eclipse.org\n\
+https://www.eclipse.org\n\
 .\n\
 Third Party Content\n\
 The Content includes items that have been sourced from third parties as set out below. If you did not receive this Content directly from the Eclipse Foundation, the following is provided for informational purposes only, and you should look to the Redistributors license for terms and conditions of use.\n\
 Apache Commons IO 2.2.0\n\
 The plug-in includes Commons IO 2.2.0 ("Commons IO") developed by the Apache Software Foundation. Therefore:\n\
 This product includes software developed by the Apache Software Foundation (\n\
-http://www.apache.org/\n\
+https://www.apache.org/\n\
 ).\n\
 The Commons IO binary code is included with no modifications except postprocessing (pack200 conditioning and signing). The corresponding Commons IO source code is located in src.zip.\n\
 Commons IO is:\n\
@@ -432,7 +432,7 @@ The Apache attribution \n\
 NOTICE.txt\n\
  file is included with the Content in accordance with 4d of the Apache License, Version 2.0.\n\
 Examples and documentation as well as updated source code for Commons IO is available at \n\
-http://commons.apache.org/io/\n\
+https://commons.apache.org/io/\n\
 .\n\
 \n\
 \n\
@@ -443,10 +443,10 @@ About This Content\n\
 June 5, 2006\n\
 License\n\
 The Eclipse Foundation makes available all content in this plug-in ("Content"). Unless otherwise indicated below, the Content is provided to you under the terms and conditions of the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is available at \n\
-http://www.eclipse.org/legal/epl-v10.html\n\
+https://www.eclipse.org/legal/epl-v10.html\n\
 . For purposes of the EPL, "Program" will mean the Content.\n\
 If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by another party ("Redistributor") and different terms and conditions may apply to your use of any object code in the Content. Check the Redistributor's license that was provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise indicated below, the terms and conditions of the EPL still apply to any source code in the Content and such source code may be obtained at \n\
-http://www.eclipse.org\n\
+https://www.eclipse.org\n\
 .\n\
 \n\
 \n\
@@ -973,7 +973,7 @@ available (as would be noted above), you may obtain a copy of\n\
 the source code corresponding to the binaries for such open\n\
 source components and modifications thereto, if any, (the\n\
 "Source Files"), by downloading the Source Files from Pivotal's website at\n\
-http://network.pivotal.io/open-source, or by sending a request, \n\
+https://network.pivotal.io/open-source, or by sending a request, \n\
 with your name and address to: Pivotal Software, Inc., 875 Howard Street, 5th\n\
 floor, San Francisco, CA 94103, Attention: General Counsel. All such requests\n\
 should clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. \n\

--- a/org.springsource.ide.eclipse.gradle.feature/open_source_licenses.txt
+++ b/org.springsource.ide.eclipse.gradle.feature/open_source_licenses.txt
@@ -165,7 +165,7 @@ Apache Commons Collections
 Copyright 2001-2008 The Apache Software Foundation
 
 This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 * Copyright 1999,2004 The Apache Software Foundation.
 *
@@ -380,17 +380,17 @@ About This Content
 June 8, 2007
 License
 The Eclipse Foundation makes available all content in this plug-in ("Content"). Unless otherwise indicated below, the Content is provided to you under the terms and conditions of the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is available at 
-http://www.eclipse.org/legal/epl-v10.html
+https://www.eclipse.org/legal/epl-v10.html
 . For purposes of the EPL, "Program" will mean the Content.
 If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by another party ("Redistributor") and different terms and conditions may apply to your use of any object code in the Content. Check the Redistributor's license that was provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise indicated below, the terms and conditions of the EPL still apply to any source code in the Content and such source code may be obtained at 
-http://www.eclipse.org
+https://www.eclipse.org
 .
 Third Party Content
 The Content includes items that have been sourced from third parties as set out below. If you did not receive this Content directly from the Eclipse Foundation, the following is provided for informational purposes only, and you should look to the Redistributors license for terms and conditions of use.
 Apache Commons IO 2.2.0
 The plug-in includes Commons IO 2.2.0 ("Commons IO") developed by the Apache Software Foundation. Therefore:
 This product includes software developed by the Apache Software Foundation (
-http://www.apache.org/
+https://www.apache.org/
 ).
 The Commons IO binary code is included with no modifications except postprocessing (pack200 conditioning and signing). The corresponding Commons IO source code is located in src.zip.
 Commons IO is:
@@ -404,7 +404,7 @@ The Apache attribution
 NOTICE.txt
  file is included with the Content in accordance with 4d of the Apache License, Version 2.0.
 Examples and documentation as well as updated source code for Commons IO is available at 
-http://commons.apache.org/io/
+https://commons.apache.org/io/
 .
 
 
@@ -415,10 +415,10 @@ About This Content
 June 5, 2006
 License
 The Eclipse Foundation makes available all content in this plug-in ("Content"). Unless otherwise indicated below, the Content is provided to you under the terms and conditions of the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is available at 
-http://www.eclipse.org/legal/epl-v10.html
+https://www.eclipse.org/legal/epl-v10.html
 . For purposes of the EPL, "Program" will mean the Content.
 If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by another party ("Redistributor") and different terms and conditions may apply to your use of any object code in the Content. Check the Redistributor's license that was provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise indicated below, the terms and conditions of the EPL still apply to any source code in the Content and such source code may be obtained at 
-http://www.eclipse.org
+https://www.eclipse.org
 .
 
 
@@ -945,7 +945,7 @@ available (as would be noted above), you may obtain a copy of
 the source code corresponding to the binaries for such open
 source components and modifications thereto, if any, (the
 "Source Files"), by downloading the Source Files from Pivotal's website at
-http://network.pivotal.io/open-source, or by sending a request, 
+https://network.pivotal.io/open-source, or by sending a request, 
 with your name and address to: Pivotal Software, Inc., 875 Howard Street, 5th
 floor, San Francisco, CA 94103, Attention: General Counsel. All such requests
 should clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. 

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/GradleTasksView.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/GradleTasksView.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/GradleTasksViewPlugin.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/GradleTasksViewPlugin.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/ProjectSelector.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/ProjectSelector.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/RefreshAction.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/RefreshAction.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/TaskLabelProvider.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/TaskLabelProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/TaskTreeContentProvider.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/TaskTreeContentProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/TasksConsoleAction.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/TasksConsoleAction.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/ToggleLinkingAction.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/ToggleLinkingAction.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/ToggleProjectTasks.java
+++ b/org.springsource.ide.eclipse.gradle.ui.taskview/src/org/springsource/ide/eclipse/gradle/ui/taskview/ToggleProjectTasks.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/ArgumentsSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/ArgumentsSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/ArgumentsValidator.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/ArgumentsValidator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/ArgumentsValidatorContext.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/ArgumentsValidatorContext.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/DependencyManagementSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/DependencyManagementSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/DistributionSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/DistributionSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleArgumentsPreferencesPage.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleArgumentsPreferencesPage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradlePreferencesPage.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradlePreferencesPage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleProjectPropertyPage.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleProjectPropertyPage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleUI.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleUI.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleUserHomeSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/GradleUserHomeSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/IPageWithSections.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/IPageWithSections.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/JVMArgumentsSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/JVMArgumentsSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/JavaHomeSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/JavaHomeSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/JavaHomeSectionImpl.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/JavaHomeSectionImpl.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/PreferencePageWithSections.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/PreferencePageWithSections.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/PrefsPageSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/PrefsPageSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/ProgramArgumentsSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/ProgramArgumentsSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/WTPPreferencesPage.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/WTPPreferencesPage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/ConsoleInplaceDialogActionDelegate.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/ConsoleInplaceDialogActionDelegate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/ConvertToGradleProjectActionDelegate.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/ConvertToGradleProjectActionDelegate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/DisableGradleNatureAction.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/DisableGradleNatureAction.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/EnableDisableDependencyManagementActionDelegate.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/EnableDisableDependencyManagementActionDelegate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/GradleProjectActionDelegate.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/GradleProjectActionDelegate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshAction.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshAction.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshAllAction.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshAllAction.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshAllHandler.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshAllHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  *      Gregory Amerson - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshDependenciesAction.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshDependenciesAction.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshSourceFoldersAction.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/actions/RefreshSourceFoldersAction.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TaskCompletionProposal.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TaskCompletionProposal.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TaskContentAssistantProcessor.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TaskContentAssistantProcessor.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TaskInformationProvider.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TaskInformationProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TasksAnnotationModel.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TasksAnnotationModel.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TasksViewer.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TasksViewer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TasksViewerConfiguration.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/editor/TasksViewerConfiguration.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/inplace/ConsoleInplaceDialog.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/inplace/ConsoleInplaceDialog.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/inplace/PopupTable.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/cli/inplace/PopupTable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/ArgumentsLaunchTabSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/ArgumentsLaunchTabSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/GradleLaunchArgumentsTab.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/GradleLaunchArgumentsTab.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/GradleLaunchShortcut.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/GradleLaunchShortcut.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/GradleLaunchTabGroup.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/GradleLaunchTabGroup.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/GradleLaunchTasksTab.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/GradleLaunchTasksTab.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/JVMArgumentsLaunchTabSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/JVMArgumentsLaunchTabSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/JavaHomeLaunchTabSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/JavaHomeLaunchTabSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/LaunchTabSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/LaunchTabSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/LaunchTabWithSections.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/LaunchTabWithSections.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/ProgramArgumentsLaunchTabSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/launch/ProgramArgumentsLaunchTabSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/DialogSettingsUtil.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/DialogSettingsUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/GradleLabelProvider.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/GradleLabelProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/PageSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/PageSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/SelectionUtils.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/SelectionUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/UIJobUtil.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/util/UIJobUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/ExistingGradleProjectFilter.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/ExistingGradleProjectFilter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleImportWizard.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleImportWizard.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleImportWizardPageOne.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleImportWizardPageOne.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleProjectTreeContentProvider.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleProjectTreeContentProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleProjectTreeLabelProvider.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleProjectTreeLabelProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleProjectTreeLabelProviderWithDescription.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/GradleProjectTreeLabelProviderWithDescription.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/NewGradleProjectWizard.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/NewGradleProjectWizard.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/NewGradleProjectWizardPage.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/NewGradleProjectWizardPage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/NewProjectNameSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/NewProjectNameSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/ProjectLocationSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/ProjectLocationSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/SampleProjectSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/SampleProjectSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/TaskRunLine.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/TaskRunLine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/WizardPageSection.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/WizardPageSection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/WizardPageWithSections.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/WizardPageWithSections.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation

--- a/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/WorkingSetGroup.java
+++ b/org.springsource.ide.eclipse.gradle.ui/src/org/springsource/ide/eclipse/gradle/ui/wizards/WorkingSetGroup.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
  * Pivotal Software, Inc. - initial API and implementation


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://lopica.sourceforge.net/os.html (200) with 1 occurrences could not be migrated:  
   ([https](https://lopica.sourceforge.net/os.html) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://network.pivotal.io/open-source (301) with 3 occurrences migrated to:  
  https://network.pivotal.io/open-source ([https](https://network.pivotal.io/open-source) result ReadTimeoutException).
* [ ] http://www.eclipse.org/downloads/ (302) with 1 occurrences migrated to:  
  https://www.eclipse.org/downloads/ ([https](https://www.eclipse.org/downloads/) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/html4/strict.dtd (ReadTimeoutException) with 4 occurrences migrated to:  
  https://www.w3.org/TR/html4/strict.dtd ([https](https://www.w3.org/TR/html4/strict.dtd) result ReadTimeoutException).
* [ ] http://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e3.7/ (UnknownHostException) with 1 occurrences migrated to:  
  https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e3.7/ ([https](https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e3.7/) result UnknownHostException).
* [ ] http://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2/ (UnknownHostException) with 1 occurrences migrated to:  
  https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2/ ([https](https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2/) result UnknownHostException).
* [ ] http://docs.codehaus.org/display/GROOVY/DSL+Descriptors+for+Groovy-Eclipse (UnknownHostException) with 1 occurrences migrated to:  
  https://docs.codehaus.org/display/GROOVY/DSL+Descriptors+for+Groovy-Eclipse ([https](https://docs.codehaus.org/display/GROOVY/DSL+Descriptors+for+Groovy-Eclipse) result UnknownHostException).
* [ ] http://groovy.codehaus.org/Eclipse+Plugin (UnknownHostException) with 3 occurrences migrated to:  
  https://groovy.codehaus.org/Eclipse+Plugin ([https](https://groovy.codehaus.org/Eclipse+Plugin) result UnknownHostException).
* [ ] http://dist.springsource.com/milestone/TOOLS/gradle (403) with 3 occurrences migrated to:  
  https://dist.springsource.com/milestone/TOOLS/gradle ([https](https://dist.springsource.com/milestone/TOOLS/gradle) result 403).
* [ ] http://dist.springsource.com/milestone/TOOLS/update/e3.7/ (403) with 2 occurrences migrated to:  
  https://dist.springsource.com/milestone/TOOLS/update/e3.7/ ([https](https://dist.springsource.com/milestone/TOOLS/update/e3.7/) result 403).
* [ ] http://dist.springsource.com/milestone/TOOLS/update/e4.2/ (403) with 2 occurrences migrated to:  
  https://dist.springsource.com/milestone/TOOLS/update/e4.2/ ([https](https://dist.springsource.com/milestone/TOOLS/update/e4.2/) result 403).
* [ ] http://dist.springsource.com/release/TOOLS/gradle (403) with 3 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/gradle ([https](https://dist.springsource.com/release/TOOLS/gradle) result 403).
* [ ] http://dist.springsource.com/snapshot/TOOLS/gradle/nightly (403) with 2 occurrences migrated to:  
  https://dist.springsource.com/snapshot/TOOLS/gradle/nightly ([https](https://dist.springsource.com/snapshot/TOOLS/gradle/nightly) result 403).
* [ ] http://dist.springsource.com/snapshot/TOOLS/nightly/e4.1/ (403) with 1 occurrences migrated to:  
  https://dist.springsource.com/snapshot/TOOLS/nightly/e4.1/ ([https](https://dist.springsource.com/snapshot/TOOLS/nightly/e4.1/) result 403).
* [ ] http://dist.springsource.com/snapshot/TOOLS/nightly/gradle (403) with 2 occurrences migrated to:  
  https://dist.springsource.com/snapshot/TOOLS/nightly/gradle ([https](https://dist.springsource.com/snapshot/TOOLS/nightly/gradle) result 403).
* [ ] http://static.springsource.org/sts/docs/2.7.0.M1/reference/html/gradle/gradle-sts-tutorial.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/sts/docs/2.7.0.M1/reference/html/gradle/gradle-sts-tutorial.html ([https](https://static.springsource.org/sts/docs/2.7.0.M1/reference/html/gradle/gradle-sts-tutorial.html) result 404).
* [ ] http://static.springsource.org/sts/docs/latest/reference/html/gradle/ (301) with 5 occurrences migrated to:  
  https://docs.spring.io/sts/docs/latest/reference/html/gradle/ ([https](https://static.springsource.org/sts/docs/latest/reference/html/gradle/) result 404).
* [ ] http://gradle.org/help-and-support (301) with 2 occurrences migrated to:  
  https://gradle.org/help-and-support ([https](https://gradle.org/help-and-support) result 404).
* [ ] http://repo.gradle.org/gradle/distributions/gradle-1.0-milestone- (404) with 1 occurrences migrated to:  
  https://repo.gradle.org/gradle/distributions/gradle-1.0-milestone- ([https](https://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-) result 404).
* [ ] http://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-3-bin.zip (404) with 2 occurrences migrated to:  
  https://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-3-bin.zip ([https](https://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-3-bin.zip) result 404).
* [ ] http://services.gradle.org/distributions/gradle- (404) with 1 occurrences migrated to:  
  https://services.gradle.org/distributions/gradle- ([https](https://services.gradle.org/distributions/gradle-) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://dist.springsource.com/release/TOOLS/update/e3.7/ with 2 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/update/e3.7/ ([https](https://dist.springsource.com/release/TOOLS/update/e3.7/) result 200).
* [ ] http://dist.springsource.com/release/TOOLS/update/e4.2/ with 2 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/update/e4.2/ ([https](https://dist.springsource.com/release/TOOLS/update/e4.2/) result 200).
* [ ] http://dist.springsource.com/snapshot/TOOLS/nightly/e3.7/ with 2 occurrences migrated to:  
  https://dist.springsource.com/snapshot/TOOLS/nightly/e3.7/ ([https](https://dist.springsource.com/snapshot/TOOLS/nightly/e3.7/) result 200).
* [ ] http://dist.springsource.com/snapshot/TOOLS/nightly/e4.2/ with 1 occurrences migrated to:  
  https://dist.springsource.com/snapshot/TOOLS/nightly/e4.2/ ([https](https://dist.springsource.com/snapshot/TOOLS/nightly/e4.2/) result 200).
* [ ] http://static.springsource.org/spring-security/site/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/ ([https](https://static.springsource.org/spring-security/site/) result 200).
* [ ] http://static.springsource.org/spring-security/site/source.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/source.html ([https](https://static.springsource.org/spring-security/site/source.html) result 200).
* [ ] http://issues.gradle.org/browse/GRADLE-1527 with 1 occurrences migrated to:  
  https://issues.gradle.org/browse/GRADLE-1527 ([https](https://issues.gradle.org/browse/GRADLE-1527) result 200).
* [ ] http://issues.gradle.org/browse/GRADLE-1555 with 1 occurrences migrated to:  
  https://issues.gradle.org/browse/GRADLE-1555 ([https](https://issues.gradle.org/browse/GRADLE-1555) result 200).
* [ ] http://issues.gradle.org/browse/GRADLE-1560 with 1 occurrences migrated to:  
  https://issues.gradle.org/browse/GRADLE-1560 ([https](https://issues.gradle.org/browse/GRADLE-1560) result 200).
* [ ] http://issues.gradle.org/browse/GRADLE-1765 with 1 occurrences migrated to:  
  https://issues.gradle.org/browse/GRADLE-1765 ([https](https://issues.gradle.org/browse/GRADLE-1765) result 200).
* [ ] http://issues.gradle.org/browse/GRADLE-1766 with 1 occurrences migrated to:  
  https://issues.gradle.org/browse/GRADLE-1766 ([https](https://issues.gradle.org/browse/GRADLE-1766) result 200).
* [ ] http://issues.gradle.org/browse/GRADLE-1792 with 2 occurrences migrated to:  
  https://issues.gradle.org/browse/GRADLE-1792 ([https](https://issues.gradle.org/browse/GRADLE-1792) result 200).
* [ ] http://issues.gradle.org/browse/GRADLE-2251 with 1 occurrences migrated to:  
  https://issues.gradle.org/browse/GRADLE-2251 ([https](https://issues.gradle.org/browse/GRADLE-2251) result 200).
* [ ] http://maven.apache.org/ with 1 occurrences migrated to:  
  https://maven.apache.org/ ([https](https://maven.apache.org/) result 200).
* [ ] http://stackoverflow.com/questions/1161297/why-are-we-getting-closedbyinterruptexception-from-filechannel-map-in-java-1-6 with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/1161297/why-are-we-getting-closedbyinterruptexception-from-filechannel-map-in-java-1-6 ([https](https://stackoverflow.com/questions/1161297/why-are-we-getting-closedbyinterruptexception-from-filechannel-map-in-java-1-6) result 200).
* [ ] http://www.apache.org/ with 6 occurrences migrated to:  
  https://www.apache.org/ ([https](https://www.apache.org/) result 200).
* [ ] http://www.eclipse.org with 6 occurrences migrated to:  
  https://www.eclipse.org ([https](https://www.eclipse.org) result 200).
* [ ] http://www.eclipse.org/legal/epl-v10.html with 263 occurrences migrated to:  
  https://www.eclipse.org/legal/epl-v10.html ([https](https://www.eclipse.org/legal/epl-v10.html) result 200).
* [ ] http://www.ibm.com/developerworks/library/os-eclipse-plugindev1/ with 1 occurrences migrated to:  
  https://www.ibm.com/developerworks/library/os-eclipse-plugindev1/ ([https](https://www.ibm.com/developerworks/library/os-eclipse-plugindev1/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://forum.springsource.org/forumdisplay.php?32-SpringSource-Tool-Suite (301) with 2 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?32-SpringSource-Tool-Suite ([https](https://forum.springsource.org/forumdisplay.php?32-SpringSource-Tool-Suite) result 301).
* [ ] http://forum.springsource.org/forumdisplay.php?f=32 (301) with 2 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?f=32 ([https](https://forum.springsource.org/forumdisplay.php?f=32) result 301).
* [ ] http://google.com with 1 occurrences migrated to:  
  https://google.com ([https](https://google.com) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://services.gradle.org/distributions/gradle-1.0-milestone- with 1 occurrences migrated to:  
  https://services.gradle.org/distributions/gradle-1.0-milestone- ([https](https://services.gradle.org/distributions/gradle-1.0-milestone-) result 301).
* [ ] http://services.gradle.org/distributions/gradle-1.3-bin.zip with 1 occurrences migrated to:  
  https://services.gradle.org/distributions/gradle-1.3-bin.zip ([https](https://services.gradle.org/distributions/gradle-1.3-bin.zip) result 301).
* [ ] http://services.gradle.org/distributions/gradle-2.1-all.zip with 2 occurrences migrated to:  
  https://services.gradle.org/distributions/gradle-2.1-all.zip ([https](https://services.gradle.org/distributions/gradle-2.1-all.zip) result 301).
* [ ] http://www.springsource.com/ with 3 occurrences migrated to:  
  https://www.springsource.com/ ([https](https://www.springsource.com/) result 301).
* [ ] http://www.springsource.org/springsource-tool-suite-download with 1 occurrences migrated to:  
  https://www.springsource.org/springsource-tool-suite-download ([https](https://www.springsource.org/springsource-tool-suite-download) result 301).
* [ ] http://commons.apache.org/io/ with 3 occurrences migrated to:  
  https://commons.apache.org/io/ ([https](https://commons.apache.org/io/) result 302).
* [ ] http://eclipse.org/tycho with 1 occurrences migrated to:  
  https://eclipse.org/tycho ([https](https://eclipse.org/tycho) result 302).
* [ ] http://springsource.com/developer/sts with 3 occurrences migrated to:  
  https://springsource.com/developer/sts ([https](https://springsource.com/developer/sts) result 302).
* [ ] http://www.springsource.org/node/feed with 1 occurrences migrated to:  
  https://www.springsource.org/node/feed ([https](https://www.springsource.org/node/feed) result 302).
* [ ] http://www.springsource.org/uaa/faq with 2 occurrences migrated to:  
  https://www.springsource.org/uaa/faq ([https](https://www.springsource.org/uaa/faq) result 302).
* [ ] http://www.springsource.org/uaa/terms_of_use with 1 occurrences migrated to:  
  https://www.springsource.org/uaa/terms_of_use ([https](https://www.springsource.org/uaa/terms_of_use) result 302).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/2001/XMLSchema with 1 occurrences