### PR TITLE
URL Cleanup

### DIFF
--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject-m6/build.gradle
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject-m6/build.gradle
@@ -7,7 +7,7 @@ subprojects {
     apply plugin: 'eclipse'
 
     repositories {
-       mavenCentral()
+       maven { url 'https://repo.maven.apache.org/maven2/' }
     }
 
     dependencies {

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject-m6/gradle/wrapper/gradle-wrapper.properties
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/multiproject-m6/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-6-bin.zip
+distributionUrl=https\://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-6-bin.zip

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/oldWrapperFormat/gradle/wrapper/gradle-wrapper.properties
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/oldWrapperFormat/gradle/wrapper/gradle-wrapper.properties
@@ -4,6 +4,6 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 distributionVersion=1.0-milestone-2
 zipStorePath=wrapper/dists
-urlRoot=http\://gradle.artifactoryonline.com/gradle/distributions
+urlRoot=https\://gradle.artifactoryonline.com/gradle/distributions
 distributionName=gradle
 distributionClassifier=bin

--- a/org.springsource.ide.eclipse.gradle.core.test/resources/projects/oldWrapperVersion/gradle/wrapper/gradle-wrapper.properties
+++ b/org.springsource.ide.eclipse.gradle.core.test/resources/projects/oldWrapperVersion/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-2-bin.zip
+distributionUrl=https\://repo.gradle.org/gradle/distributions/gradle-1.0-milestone-2-bin.zip


### PR DESCRIPTION
- Ensure Gradle Wrapper is downloaded via https
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.